### PR TITLE
Feature/ranges part1

### DIFF
--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -28,6 +28,10 @@ endfunction()
 
 add_subdirectory( src/tools/Log/test )
 
+add_subdirectory( src/tools/concepts/Requires/test )
+add_subdirectory( src/tools/concepts/IsRange/test )
+add_subdirectory( src/tools/concepts/IsIterator/test )
+
 add_subdirectory( src/tools/ranges/IteratorView/test )
 add_subdirectory( src/tools/ranges/TransformIterator/test )
 add_subdirectory( src/tools/ranges/make_view/test )

--- a/src/tools/concepts.hpp
+++ b/src/tools/concepts.hpp
@@ -1,0 +1,4 @@
+#include "tools/concepts/Require.hpp"
+
+#include "tools/concepts/IsIterator.hpp"
+#include "tools/concepts/IsRange.hpp"

--- a/src/tools/concepts/IsIterator.hpp
+++ b/src/tools/concepts/IsIterator.hpp
@@ -1,0 +1,28 @@
+#ifndef NJOY_TOOLS_CONCEPTS_ISITERATOR
+#define NJOY_TOOLS_CONCEPTS_ISITERATOR
+
+// system includes
+#include <type_traits>
+
+// other includes
+
+namespace njoy {
+namespace tools {
+namespace concepts {
+
+  template< typename Iterator >
+  using iterator_category =
+    typename std::iterator_traits< Iterator >::iterator_category;
+
+  template< typename Iterator, typename = void >
+  struct IsIterator : std::false_type {};
+
+  template< typename Iterator >
+  struct IsIterator< Iterator,
+                     std::void_t< iterator_category< Iterator > > > : std::true_type {};
+
+} // ranges namespace
+} // tools namespace
+} // njoy namespace
+
+#endif

--- a/src/tools/concepts/IsIterator.hpp
+++ b/src/tools/concepts/IsIterator.hpp
@@ -14,12 +14,52 @@ namespace concepts {
   using iterator_category =
     typename std::iterator_traits< Iterator >::iterator_category;
 
+  // sfinae structures for iterator objects
+
   template< typename Iterator, typename = void >
   struct IsIterator : std::false_type {};
 
   template< typename Iterator >
-  struct IsIterator< Iterator,
-                     std::void_t< iterator_category< Iterator > > > : std::true_type {};
+  struct IsIterator<
+           Iterator,
+           std::void_t< iterator_category< Iterator > > > : std::true_type {};
+
+  // the following template aliases only work on iterators
+
+  // sfinae structures for input iterator objects
+
+  template< typename Iterator >
+  using IsInputIterator =
+    typename std::is_base_of< std::input_iterator_tag,
+                              iterator_category< Iterator > >;
+
+  // sfinae structures for output iterator objects
+
+  template< typename Iterator >
+  using IsOutputIterator =
+    typename std::is_base_of< std::output_iterator_tag,
+                              iterator_category< Iterator > >;
+
+  // sfinae structures for forward iterator objects
+
+  template< typename Iterator >
+  using IsForwardIterator =
+    typename std::is_base_of< std::forward_iterator_tag,
+                              iterator_category< Iterator > >;
+
+  // sfinae structures for bidirectional iterator objects
+
+  template< typename Iterator >
+  using IsBidirectionalIterator =
+    typename std::is_base_of< std::bidirectional_iterator_tag,
+                              iterator_category< Iterator > >;
+
+  // sfinae structures for random access iterator objects
+
+  template< typename Iterator >
+  using IsRandomAccessIterator =
+    typename std::is_base_of< std::random_access_iterator_tag,
+                              iterator_category< Iterator > >;
 
 } // ranges namespace
 } // tools namespace

--- a/src/tools/concepts/IsIterator/test/CMakeLists.txt
+++ b/src/tools/concepts/IsIterator/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_cpp_test( concepts.IsIterator IsIterator.test.cpp )

--- a/src/tools/concepts/IsIterator/test/IsIterator.test.cpp
+++ b/src/tools/concepts/IsIterator/test/IsIterator.test.cpp
@@ -5,13 +5,19 @@
 #include "tools/concepts/IsIterator.hpp"
 
 // other includes
-#include <vector>
+#include <iterator>
+#include <forward_list>
+#include <list>
 #include <map>
+#include <unordered_map>
+#include <set>
+#include <unordered_set>
+#include <vector>
 
 // convenience typedefs
 using namespace njoy::tools::concepts;
 
-SCENARIO( "IsIterator" ) {
+SCENARIO( "IsIterator sfinae objects" ) {
 
   GIVEN( "different types" ) {
 
@@ -19,12 +25,152 @@ SCENARIO( "IsIterator" ) {
 
       THEN( "true is returned for iterators and false for everything else" ) {
 
+        // non iterator type
         CHECK( false == IsIterator< int >::value );
 
-        CHECK( true == IsIterator< std::vector< int >::iterator >::value );
-        CHECK( true == IsIterator< std::vector< int >::const_iterator >::value );
+        // input iterator types
+        CHECK( true == IsIterator< std::istream_iterator< int > >::value );
 
-        CHECK( true == IsIterator< int* >::value );
+        // output iterator types
+        CHECK( true == IsIterator< std::ostream_iterator< int > >::value );
+
+        // forward iterator types
+        CHECK( true == IsIterator< std::forward_list< int >::iterator >::value );
+        CHECK( true == IsIterator< std::unordered_set< int >::iterator >::value );
+        CHECK( true == IsIterator< std::unordered_map< int, int >::iterator >::value );
+
+        // bidirectional iterator types
+        CHECK( true == IsIterator< std::list< int >::iterator >::value );
+        CHECK( true == IsIterator< std::set< int >::iterator >::value );
+        CHECK( true == IsIterator< std::map< int, int >::iterator >::value );
+
+        // random access iterator types
+        CHECK( true == IsIterator< std::vector< int >::iterator >::value );
+      } // THEN
+    } // WHEN
+
+    WHEN( "when applying IsInputIterator" ) {
+
+      THEN( "true is returned for iterators that conform to input iterators" ) {
+
+        // input iterator type
+        CHECK( true == IsInputIterator< std::istream_iterator< int > >::value );
+
+        // output iterator types
+        CHECK( false == IsInputIterator< std::ostream_iterator< int > >::value );
+
+        // forward iterator types
+        CHECK( true == IsInputIterator< std::forward_list< int >::iterator >::value );
+        CHECK( true == IsInputIterator< std::unordered_set< int >::iterator >::value );
+        CHECK( true == IsInputIterator< std::unordered_map< int, int >::iterator >::value );
+
+        // bidirectional iterator types
+        CHECK( true == IsInputIterator< std::list< int >::iterator >::value );
+        CHECK( true == IsInputIterator< std::set< int >::iterator >::value );
+        CHECK( true == IsInputIterator< std::map< int, int >::iterator >::value );
+
+        // random access iterator types
+        CHECK( true == IsInputIterator< std::vector< int >::iterator >::value );
+      } // THEN
+    } // WHEN
+
+    WHEN( "when applying IsOutputIterator" ) {
+
+      THEN( "true is returned for iterators that conform to output iterators" ) {
+
+        // input iterator types
+        CHECK( false == IsOutputIterator< std::istream_iterator< int > >::value );
+
+        // output iterator types
+        CHECK( true == IsOutputIterator< std::ostream_iterator< int > >::value );
+
+        // forward iterator types
+        CHECK( false == IsOutputIterator< std::forward_list< int >::iterator >::value );
+        CHECK( false == IsOutputIterator< std::unordered_set< int >::iterator >::value );
+        CHECK( false == IsOutputIterator< std::unordered_map< int, int >::iterator >::value );
+
+        // bidirectional iterator types
+        CHECK( false == IsOutputIterator< std::list< int >::iterator >::value );
+        CHECK( false == IsOutputIterator< std::set< int >::iterator >::value );
+        CHECK( false == IsOutputIterator< std::map< int, int >::iterator >::value );
+
+        // random access iterator types
+        CHECK( false == IsOutputIterator< std::vector< int >::iterator >::value );
+      } // THEN
+    } // WHEN
+
+    WHEN( "when applying IsForwardIterator" ) {
+
+      THEN( "true is returned for iterators that conform to forward iterators" ) {
+
+        // input iterator types
+        CHECK( false == IsForwardIterator< std::istream_iterator< int > >::value );
+
+        // output iterator types
+        CHECK( false == IsForwardIterator< std::ostream_iterator< int > >::value );
+
+        // forward iterator types
+        CHECK( true == IsForwardIterator< std::forward_list< int >::iterator >::value );
+        CHECK( true == IsForwardIterator< std::unordered_set< int >::iterator >::value );
+        CHECK( true == IsForwardIterator< std::unordered_map< int, int >::iterator >::value );
+
+        // bidirectional iterator types
+        CHECK( true == IsForwardIterator< std::list< int >::iterator >::value );
+        CHECK( true == IsForwardIterator< std::set< int >::iterator >::value );
+        CHECK( true == IsForwardIterator< std::map< int, int >::iterator >::value );
+
+        // random access iterator types
+        CHECK( true == IsForwardIterator< std::vector< int >::iterator >::value );
+      } // THEN
+    } // WHEN
+
+    WHEN( "when applying IsBidirectionalIterator" ) {
+
+      THEN( "true is returned for iterators that conform to bidirectional iterators" ) {
+
+        // input iterator types
+        CHECK( false == IsBidirectionalIterator< std::istream_iterator< int > >::value );
+
+        // output iterator types
+        CHECK( false == IsBidirectionalIterator< std::ostream_iterator< int > >::value );
+
+        // forward iterator types
+        CHECK( false == IsBidirectionalIterator< std::forward_list< int >::iterator >::value );
+        CHECK( false == IsBidirectionalIterator< std::unordered_set< int >::iterator >::value );
+        CHECK( false == IsBidirectionalIterator< std::unordered_map< int, int >::iterator >::value );
+
+        // bidirectional iterator types
+        CHECK( true == IsBidirectionalIterator< std::list< int >::iterator >::value );
+        CHECK( true == IsBidirectionalIterator< std::set< int >::iterator >::value );
+        CHECK( true == IsBidirectionalIterator< std::map< int, int >::iterator >::value );
+
+        // random access iterator types
+        CHECK( true == IsBidirectionalIterator< std::vector< int >::iterator >::value );
+      } // THEN
+    } // WHEN
+
+    WHEN( "when applying IsRandomAccessIterator" ) {
+
+      THEN( "true is returned for iterators that conform to random access iterators" ) {
+
+        // input iterator types
+        CHECK( false == IsRandomAccessIterator< std::istream_iterator< int > >::value );
+
+        // output iterator types
+        CHECK( false == IsRandomAccessIterator< std::ostream_iterator< int > >::value );
+
+        // forward iterator types
+        CHECK( false == IsRandomAccessIterator< std::forward_list< int >::iterator >::value );
+        CHECK( false == IsRandomAccessIterator< std::unordered_set< int >::iterator >::value );
+        CHECK( false == IsRandomAccessIterator< std::unordered_map< int, int >::iterator >::value );
+
+        // bidirectional iterator types
+        CHECK( false == IsRandomAccessIterator< std::list< int >::iterator >::value );
+        CHECK( false == IsRandomAccessIterator< std::set< int >::iterator >::value );
+        CHECK( false == IsRandomAccessIterator< std::map< int, int >::iterator >::value );
+
+        // random access iterator types
+        CHECK( true == IsRandomAccessIterator< std::vector< int >::iterator >::value );
       } // THEN
     } // WHEN
   } // GIVEN

--- a/src/tools/concepts/IsIterator/test/IsIterator.test.cpp
+++ b/src/tools/concepts/IsIterator/test/IsIterator.test.cpp
@@ -1,0 +1,31 @@
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+
+// what we are testing
+#include "tools/concepts/IsIterator.hpp"
+
+// other includes
+#include <vector>
+#include <map>
+
+// convenience typedefs
+using namespace njoy::tools::concepts;
+
+SCENARIO( "IsIterator" ) {
+
+  GIVEN( "different types" ) {
+
+    WHEN( "when applying IsIterator" ) {
+
+      THEN( "true is returned for iterators and false for everything else" ) {
+
+        CHECK( false == IsIterator< int >::value );
+
+        CHECK( true == IsIterator< std::vector< int >::iterator >::value );
+        CHECK( true == IsIterator< std::vector< int >::const_iterator >::value );
+
+        CHECK( true == IsIterator< int* >::value );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO

--- a/src/tools/concepts/IsRange.hpp
+++ b/src/tools/concepts/IsRange.hpp
@@ -1,0 +1,26 @@
+#ifndef NJOY_TOOLS_CONCEPTS_ISRANGE
+#define NJOY_TOOLS_CONCEPTS_ISRANGE
+
+// system includes
+#include <type_traits>
+
+// other includes
+
+namespace njoy {
+namespace tools {
+namespace concepts {
+
+  template< typename Range, typename = void >
+  struct IsRange : std::false_type {};
+
+  template< typename Range >
+  struct IsRange< Range,
+                  std::void_t< decltype( std::begin( std::declval< Range >() ) ),
+                               decltype( std::end( std::declval< Range >() ) )
+                             > > : std::true_type {};
+
+} // ranges namespace
+} // tools namespace
+} // njoy namespace
+
+#endif

--- a/src/tools/concepts/IsRange/test/CMakeLists.txt
+++ b/src/tools/concepts/IsRange/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_cpp_test( concepts.IsRange IsRange.test.cpp )

--- a/src/tools/concepts/IsRange/test/IsRange.test.cpp
+++ b/src/tools/concepts/IsRange/test/IsRange.test.cpp
@@ -1,0 +1,30 @@
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+
+// what we are testing
+#include "tools/concepts/IsRange.hpp"
+
+// other includes
+#include <vector>
+#include <map>
+
+// convenience typedefs
+using namespace njoy::tools::concepts;
+
+SCENARIO( "IsRange" ) {
+
+  GIVEN( "different types" ) {
+
+    WHEN( "when applying IsRange" ) {
+
+      THEN( "true is returned for ranges and false for everything else" ) {
+
+        CHECK( false == IsRange< int >::value );
+
+        CHECK( true == IsRange< std::vector< int > >::value );
+        CHECK( true == IsRange< const std::vector< int > >::value );
+        CHECK( true == IsRange< std::map< int, int > >::value );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO

--- a/src/tools/concepts/Requires.hpp
+++ b/src/tools/concepts/Requires.hpp
@@ -1,0 +1,20 @@
+#ifndef NJOY_TOOLS_CONCEPTS_REQUIRES
+#define NJOY_TOOLS_CONCEPTS_REQUIRES
+
+// system includes
+#include <type_traits>
+
+// other includes
+
+namespace njoy {
+namespace tools {
+namespace concepts {
+
+  template< bool TrueFalse, template< typename...> class Concept, typename... T >
+  using Requires = std::enable_if_t< Concept< T... >::value == TrueFalse, bool >;
+
+} // ranges namespace
+} // tools namespace
+} // njoy namespace
+
+#endif

--- a/src/tools/concepts/Requires.hpp
+++ b/src/tools/concepts/Requires.hpp
@@ -11,7 +11,7 @@ namespace tools {
 namespace concepts {
 
   template< bool TrueFalse, template< typename...> class Concept, typename... T >
-  using Requires = std::enable_if_t< Concept< T... >::value == TrueFalse, bool >;
+  using Requires = typename std::enable_if< Concept< T... >::value == TrueFalse, bool >::type;
 
 } // ranges namespace
 } // tools namespace

--- a/src/tools/concepts/Requires/test/CMakeLists.txt
+++ b/src/tools/concepts/Requires/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_cpp_test( concepts.Requires Requires.test.cpp )

--- a/src/tools/concepts/Requires/test/Requires.test.cpp
+++ b/src/tools/concepts/Requires/test/Requires.test.cpp
@@ -1,0 +1,32 @@
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+
+// what we are testing
+#include "tools/concepts/Requires.hpp"
+
+// other includes
+
+// convenience typedefs
+using namespace njoy::tools::concepts;
+
+template< typename T, Requires< true, std::is_integral, T > = true >
+bool integer_type( const T& ){ return true; }
+
+template< typename T, Requires< false, std::is_integral, T > = true >
+bool integer_type( const T& ){ return false; }
+
+SCENARIO( "Require" ) {
+
+  GIVEN( "different types" ) {
+
+    WHEN( "when applying Require" ) {
+
+      THEN( "true is returned for integers and false for everything else" ) {
+
+        CHECK( true == integer_type( 1 ) );
+        CHECK( false == integer_type( 1.0 ) );
+        CHECK( false == integer_type( std::vector< int >{} ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO

--- a/src/tools/ranges/IteratorView.hpp
+++ b/src/tools/ranges/IteratorView.hpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 
 // other includes
+#include "tools/ranges/ViewBase.hpp"
 
 namespace njoy {
 namespace tools {
@@ -17,11 +18,14 @@ namespace ranges {
  *
  *  Currently only defined for random access iterators.
  */
-template < class Iterator,
+template < typename Iterator,
            std::enable_if_t<
                std::is_same< typename std::iterator_traits< Iterator >::iterator_category,
                              std::random_access_iterator_tag >::value, bool > = true >
-class IteratorView {
+class IteratorView : public ViewBase< IteratorView< Iterator > > {
+
+  /* type aliases */
+  using Parent = ViewBase< IteratorView< Iterator > >;
 
 public:
 
@@ -69,84 +73,14 @@ public:
    */
   constexpr iterator end() const noexcept { return end_; }
 
-  /**
-   *  @brief Return the reference to the front element of the view
-   */
-  constexpr decltype(auto) front() const noexcept {
-
-    return *( this->begin() );
-  }
-
-  /**
-   *  @brief Return the reference to the back element of the view
-   */
-  constexpr decltype(auto) back() const noexcept {
-
-    return *( std::prev( this->end() ) );
-  }
-
-  /**
-   *  @brief Return whether or not the view is empty
-   */
-  constexpr bool empty() const noexcept { return this->begin() == this->end(); }
-
-  /**
-   *  @brief Return the size of the iterator view
-   */
-  constexpr size_type size() const noexcept {
-
-    return std::distance( this->begin(), this->end() );
-  }
-
-  /**
-   *  @brief Return an element at a given index
-   *
-   *  No range checking is performed.
-   *
-   *  @param[in] i    the index
-   */
-  constexpr decltype(auto) operator[]( size_type i ) const noexcept {
-
-    return *( std::next( this->begin(), i ) );
-  }
-
-  /**
-   *  @brief Return an element at a given index with range checking
-   *
-   *  @param[in] i    the index
-   */
-  constexpr decltype(auto) at( size_type i ) const {
-
-    if ( i >= this->size() ) {
-
-      throw std::out_of_range( "Index out of range in IteratorView: " +
-                               std::to_string( i ) + " >= size (" +
-                               std::to_string( this->size() ) + ")" );
-    }
-    return this->operator[]( i );
-  }
-
-  /**
-   *  @brief Verify if the IteratorView is equal to another container
-   *
-   *  @param[in] other    the other container to compare with
-   */
-  template < typename Container >
-  constexpr bool operator==( const Container& other ) const {
-
-    return std::equal( this->begin(), this->end(), other.begin(), other.end() );
-  }
-
-  /**
-   *  @brief Verify if the IteratorView is equal to another container
-   *
-   *  @param[in] other    the other container to compare with
-   */
-  template < typename Container >
-  constexpr bool operator!=( const Container& other ) const {
-
-    return !this->operator==( other );
-  }
+  using Parent::front;
+  using Parent::back;
+  using Parent::empty;
+  using Parent::size;
+  using Parent::operator[];
+  using Parent::at;
+  using Parent::operator==;
+  using Parent::operator!=;
 };
 
 /**

--- a/src/tools/ranges/IteratorView.hpp
+++ b/src/tools/ranges/IteratorView.hpp
@@ -18,14 +18,8 @@ namespace ranges {
  *
  *  Currently only defined for random access iterators.
  */
-template < typename Iterator,
-           std::enable_if_t<
-               std::is_same< typename std::iterator_traits< Iterator >::iterator_category,
-                             std::random_access_iterator_tag >::value, bool > = true >
+template < typename Iterator >
 class IteratorView : public ViewBase< IteratorView< Iterator > > {
-
-  /* type aliases */
-  using Parent = ViewBase< IteratorView< Iterator > >;
 
 public:
 
@@ -72,15 +66,6 @@ public:
    *  @brief Return the end iterator to the view
    */
   constexpr iterator end() const noexcept { return end_; }
-
-  using Parent::front;
-  using Parent::back;
-  using Parent::empty;
-  using Parent::size;
-  using Parent::operator[];
-  using Parent::at;
-  using Parent::operator==;
-  using Parent::operator!=;
 };
 
 /**

--- a/src/tools/ranges/IteratorView/test/IteratorView.test.cpp
+++ b/src/tools/ranges/IteratorView/test/IteratorView.test.cpp
@@ -29,6 +29,7 @@ SCENARIO( "IteratorView" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         // the following should not compile: no random access iterator
         // CHECK( -2 == chunk[0] );
@@ -57,6 +58,7 @@ SCENARIO( "IteratorView" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         // the following should not compile: no random access iterator
         // CHECK( -2 == chunk[0] );
@@ -83,6 +85,7 @@ SCENARIO( "IteratorView" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         CHECK( -2 == chunk[0] );
         CHECK( -1 == chunk[1] );

--- a/src/tools/ranges/IteratorView/test/IteratorView.test.cpp
+++ b/src/tools/ranges/IteratorView/test/IteratorView.test.cpp
@@ -5,13 +5,42 @@
 #include "tools/ranges/IteratorView.hpp"
 
 // other includes
+#include <forward_list>
+#include <list>
+#include <vector>
 
 // convenience typedefs
 using namespace njoy::tools::ranges;
 
 SCENARIO( "IteratorView" ) {
 
-  GIVEN( "a container with values" ) {
+  GIVEN( "a container with bidirectional iterators" ) {
+
+    std::list< int > values = { -2, -1, 0, 1, 2 };
+
+    WHEN( "when iterators are used" ) {
+
+      IteratorView< std::list< int >::iterator > chunk( values.begin(), values.end() );
+
+      THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
+
+        CHECK( 5 == chunk.size() );
+        CHECK( false == chunk.empty() );
+
+        // the following should not compile: no random access iterator
+        // CHECK( -2 == chunk[0] );
+        // CHECK( -2 == chunk.at(0) );
+
+        CHECK( -2 == chunk.front() );
+        CHECK(  2 == chunk.back() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "a container with random access iterators" ) {
 
     std::vector< int > values = { -2, -1, 0, 1, 2 };
 
@@ -20,6 +49,9 @@ SCENARIO( "IteratorView" ) {
       IteratorView< std::vector< int >::iterator > chunk( values.begin(), values.end() );
 
       THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
@@ -62,7 +94,7 @@ SCENARIO( "IteratorView" ) {
     IteratorView< std::vector< double >::iterator > view1( copy1.begin(), copy1.end() );
     IteratorView< std::vector< double >::iterator > view2( copy2.begin(), copy2.end() );
 
-    WHEN( "when make comparison functions are used" ) {
+    WHEN( "when comparison functions are used" ) {
 
       THEN( "views and containers can be compared" ) {
 

--- a/src/tools/ranges/IteratorView/test/IteratorView.test.cpp
+++ b/src/tools/ranges/IteratorView/test/IteratorView.test.cpp
@@ -14,6 +14,34 @@ using namespace njoy::tools::ranges;
 
 SCENARIO( "IteratorView" ) {
 
+  GIVEN( "a container with forward iterators" ) {
+
+    std::forward_list< int > values = { -2, -1, 0, 1, 2 };
+
+    WHEN( "when iterators are used" ) {
+
+      IteratorView< std::forward_list< int >::iterator > chunk( values.begin(), values.end() );
+
+      THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
+
+        CHECK( 5 == chunk.size() );
+        CHECK( false == chunk.empty() );
+
+        // the following should not compile: no random access iterator
+        // CHECK( -2 == chunk[0] );
+        // CHECK( -2 == chunk.at(0) );
+
+        CHECK( -2 == chunk.front() );
+
+        // the following should not compile: no bidirectional iterator
+        // CHECK(  2 == chunk.back() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
   GIVEN( "a container with bidirectional iterators" ) {
 
     std::list< int > values = { -2, -1, 0, 1, 2 };

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -5,6 +5,9 @@
 #include <stdexcept>
 
 // other includes
+#include "tools/concepts/Requires.hpp"
+#include "tools/concepts/IsRange.hpp"
+#include "tools/concepts/IsIterator.hpp"
 
 namespace njoy {
 namespace tools {
@@ -22,13 +25,13 @@ class ViewBase {
 
   constexpr Derived& derived() noexcept {
 
-		return static_cast< Derived& >( *this );
-	}
+    return static_cast< Derived& >( *this );
+  }
 
-	constexpr const Derived& derived() const noexcept {
+  constexpr const Derived& derived() const noexcept {
 
-		return static_cast< const Derived& >( *this );
-	}
+    return static_cast< const Derived& >( *this );
+  }
 
 public:
 
@@ -37,6 +40,9 @@ public:
   /**
    *  @brief Return the reference to the front element of the view
    */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
   constexpr decltype(auto) front() const noexcept {
 
     return *( this->derived().begin() );
@@ -45,6 +51,9 @@ public:
   /**
    *  @brief Return the reference to the back element of the view
    */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
   constexpr decltype(auto) back() const noexcept {
 
     return *( std::prev( this->derived().end() ) );
@@ -53,6 +62,9 @@ public:
   /**
    *  @brief Return whether or not the view is empty
    */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
   constexpr bool empty() const noexcept {
 
     return this->derived().begin() == this->derived().end();
@@ -61,6 +73,9 @@ public:
   /**
    *  @brief Return the size of the iterator view
    */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
   constexpr std::size_t size() const noexcept {
 
     return std::distance( this->derived().begin(), this->derived().end() );
@@ -73,6 +88,9 @@ public:
    *
    *  @param[in] i    the index
    */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsRandomAccessIterator,
+                                 typename Range::iterator > = true >
   constexpr decltype(auto) operator[]( std::size_t i ) const noexcept {
 
     return *( std::next( this->derived().begin(), i ) );
@@ -83,6 +101,9 @@ public:
    *
    *  @param[in] i    the index
    */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsRandomAccessIterator,
+                                 typename Range::iterator > = true >
   constexpr decltype(auto) at( std::size_t i ) const {
 
     if ( i >= this->size() ) {

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -1,0 +1,125 @@
+#ifndef NJOY_TOOLS_RANGES_VIEWBASE
+#define NJOY_TOOLS_RANGES_VIEWBASE
+
+// system includes
+#include <stdexcept>
+
+// other includes
+
+namespace njoy {
+namespace tools {
+namespace ranges {
+
+/**
+ *
+ *  @brief A base class for views
+ *
+ *  This CRTP base class assumes the Derived range has a begin() and end()
+ *  method that define the begin and end iterator to the Derived range.
+ */
+template < typename Derived >
+class ViewBase {
+
+  constexpr Derived& derived() noexcept {
+
+		return static_cast< Derived& >( *this );
+	}
+
+	constexpr const Derived& derived() const noexcept {
+
+		return static_cast< const Derived& >( *this );
+	}
+
+public:
+
+  /* methods */
+
+  /**
+   *  @brief Return the reference to the front element of the view
+   */
+  constexpr decltype(auto) front() const noexcept {
+
+    return *( this->derived().begin() );
+  }
+
+  /**
+   *  @brief Return the reference to the back element of the view
+   */
+  constexpr decltype(auto) back() const noexcept {
+
+    return *( std::prev( this->derived().end() ) );
+  }
+
+  /**
+   *  @brief Return whether or not the view is empty
+   */
+  constexpr bool empty() const noexcept {
+
+    return this->derived().begin() == this->derived().end();
+  }
+
+  /**
+   *  @brief Return the size of the iterator view
+   */
+  constexpr std::size_t size() const noexcept {
+
+    return std::distance( this->derived().begin(), this->derived().end() );
+  }
+
+  /**
+   *  @brief Return an element at a given index
+   *
+   *  No range checking is performed.
+   *
+   *  @param[in] i    the index
+   */
+  constexpr decltype(auto) operator[]( std::size_t i ) const noexcept {
+
+    return *( std::next( this->derived().begin(), i ) );
+  }
+
+  /**
+   *  @brief Return an element at a given index with range checking
+   *
+   *  @param[in] i    the index
+   */
+  constexpr decltype(auto) at( std::size_t i ) const {
+
+    if ( i >= this->size() ) {
+
+      throw std::out_of_range( "Index out of range: " +
+                               std::to_string( i ) + " >= size (" +
+                               std::to_string( this->size() ) + ")" );
+    }
+    return this->operator[]( i );
+  }
+
+  /**
+   *  @brief Verify if the IteratorView is equal to another container
+   *
+   *  @param[in] other    the other container to compare with
+   */
+  template < typename Container >
+  constexpr bool operator==( const Container& other ) const {
+
+    return std::equal( this->derived().begin(), this->derived().end(),
+                       other.begin(), other.end() );
+  }
+
+  /**
+   *  @brief Verify if the IteratorView is equal to another container
+   *
+   *  @param[in] other    the other container to compare with
+   */
+  template < typename Container >
+  constexpr bool operator!=( const Container& other ) const {
+
+    return !this->operator==( other );
+  }
+};
+
+} // ranges namespace
+} // tools namespace
+} // njoy namespace
+
+#endif

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -2,6 +2,7 @@
 #define NJOY_TOOLS_RANGES_VIEWBASE
 
 // system includes
+#include <cassert>
 #include <stdexcept>
 
 // other includes
@@ -45,6 +46,7 @@ public:
                                  typename Range::iterator > = true >
   constexpr decltype(auto) front() const noexcept {
 
+    assert( ( !this->empty(), "front(): view is empty" ) );
     return *( this->derived().begin() );
   }
 
@@ -56,6 +58,7 @@ public:
                                  typename Range::iterator > = true >
   constexpr decltype(auto) back() const noexcept {
 
+    assert( ( !this->empty(), "back(): view is empty" ) );
     return *( std::prev( this->derived().end() ) );
   }
 

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -38,6 +38,39 @@ public:
   /* methods */
 
   /**
+   *  @brief Return whether or not the view is empty
+   */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
+  constexpr bool empty() const noexcept {
+
+    return this->derived().begin() == this->derived().end();
+  }
+
+  /**
+   *  @brief Return whether or not the view is empty
+   */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
+  constexpr explicit operator bool() const noexcept {
+
+    return this->empty();
+  }
+
+  /**
+   *  @brief Return the size of the iterator view
+   */
+  template < typename Range = Derived,
+             concepts::Requires< true, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
+  constexpr std::size_t size() const noexcept {
+
+    return std::distance( this->derived().begin(), this->derived().end() );
+  }
+
+  /**
    *  @brief Return the reference to the front element of the view
    */
   template < typename Range = Derived,
@@ -57,28 +90,6 @@ public:
   constexpr decltype(auto) back() const noexcept {
 
     return *( std::prev( this->derived().end() ) );
-  }
-
-  /**
-   *  @brief Return whether or not the view is empty
-   */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
-  constexpr bool empty() const noexcept {
-
-    return this->derived().begin() == this->derived().end();
-  }
-
-  /**
-   *  @brief Return the size of the iterator view
-   */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
-  constexpr std::size_t size() const noexcept {
-
-    return std::distance( this->derived().begin(), this->derived().end() );
   }
 
   /**

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -40,10 +40,11 @@ public:
   /**
    *  @brief Return whether or not the view is empty
    */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
   constexpr bool empty() const noexcept {
+
+    static_assert(
+      concepts::IsForwardIterator< typename Derived::iterator >::value == true,
+      "the empty() method can only be made available for forward iterators" );
 
     return this->derived().begin() == this->derived().end();
   }
@@ -51,10 +52,11 @@ public:
   /**
    *  @brief Return whether or not the view is empty
    */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
   constexpr explicit operator bool() const noexcept {
+
+    static_assert(
+      concepts::IsForwardIterator< typename Derived::iterator >::value == true,
+      "the operator bool() method can only be made available for forward iterators" );
 
     return this->empty();
   }
@@ -62,10 +64,11 @@ public:
   /**
    *  @brief Return the size of the iterator view
    */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
   constexpr std::size_t size() const noexcept {
+
+    static_assert(
+      concepts::IsForwardIterator< typename Derived::iterator >::value == true,
+      "the size() method can only be made available for forward iterators" );
 
     return std::distance( this->derived().begin(), this->derived().end() );
   }
@@ -73,10 +76,11 @@ public:
   /**
    *  @brief Return the reference to the front element of the view
    */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
   constexpr decltype(auto) front() const noexcept {
+
+    static_assert(
+      concepts::IsForwardIterator< typename Derived::iterator >::value == true,
+      "the front() method can only be made available for forward iterators" );
 
     return *( this->derived().begin() );
   }
@@ -84,10 +88,11 @@ public:
   /**
    *  @brief Return the reference to the back element of the view
    */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsBidirectionalIterator,
-                                 typename Range::iterator > = true >
   constexpr decltype(auto) back() const noexcept {
+
+    static_assert(
+      concepts::IsBidirectionalIterator< typename Derived::iterator >::value == true,
+      "the back() method can only be made available for bidirectional iterators" );
 
     return *( std::prev( this->derived().end() ) );
   }
@@ -99,10 +104,11 @@ public:
    *
    *  @param[in] i    the index
    */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsRandomAccessIterator,
-                                 typename Range::iterator > = true >
   constexpr decltype(auto) operator[]( std::size_t i ) const noexcept {
+
+    static_assert(
+      concepts::IsRandomAccessIterator< typename Derived::iterator >::value == true,
+      "the operator[] method can only be made available for random access iterators" );
 
     return *( std::next( this->derived().begin(), i ) );
   }
@@ -112,10 +118,11 @@ public:
    *
    *  @param[in] i    the index
    */
-  template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsRandomAccessIterator,
-                                 typename Range::iterator > = true >
   constexpr decltype(auto) at( std::size_t i ) const {
+
+    static_assert(
+      concepts::IsRandomAccessIterator< typename Derived::iterator >::value == true,
+      "the at() method can only be made available for random access iterators" );
 
     if ( i >= this->size() ) {
 
@@ -153,85 +160,6 @@ public:
   constexpr bool operator!=( const Container& other ) const {
 
     return !this->operator==( other );
-  }
-
-  // the following code is added to make compiler errors more comprehensible
-
-  template < typename Range = Derived,
-             concepts::Requires< false, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
-  constexpr bool empty() const noexcept {
-
-    static_assert( 
-      concepts::IsForwardIterator< typename Range::iterator >::value == true, 
-      "the empty() method can only be made available for forward iterators" );
-    return true;
-  }
-
-  template < typename Range = Derived,
-             concepts::Requires< false, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
-  constexpr explicit operator bool() const noexcept {
-
-    static_assert( 
-      concepts::IsForwardIterator< typename Range::iterator >::value == true, 
-      "the operator bool() method can only be made available for forward iterators" );
-    return true;
-  }
-
-  template < typename Range = Derived,
-             concepts::Requires< false, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
-  constexpr std::size_t size() const noexcept {
-
-    static_assert( 
-      concepts::IsForwardIterator< typename Range::iterator >::value == true, 
-      "the size() method can only be made available for forward iterators" );
-    return std::size_t{};
-  }
-
-  template < typename Range = Derived,
-             concepts::Requires< false, concepts::IsForwardIterator,
-                                 typename Range::iterator > = true >
-  constexpr decltype(auto) front() const noexcept {
-
-    static_assert( 
-      concepts::IsBidirectionalIterator< typename Range::iterator >::value == true, 
-      "the front() method can only be made available for bidirectional iterators" );
-    return typename Derived::value_type{};
-  }
-
-  template < typename Range = Derived,
-             concepts::Requires< false, concepts::IsBidirectionalIterator,
-                                 typename Range::iterator > = true >
-  constexpr decltype(auto) back() const noexcept {
-
-    static_assert( 
-      concepts::IsBidirectionalIterator< typename Range::iterator >::value == true, 
-      "the back() method can only be made available for bidirectional iterators" );
-    return typename Derived::value_type{};
-  }
-
-  template < typename Range = Derived,
-             concepts::Requires< false, concepts::IsRandomAccessIterator,
-                                 typename Range::iterator > = true >
-  constexpr decltype(auto) operator[]( std::size_t i ) const {
-
-    static_assert( 
-      concepts::IsRandomAccessIterator< typename Range::iterator >::value == true, 
-      "the operator[] method can only be made available for random access iterators" );
-    return typename Derived::value_type{};
-  }
-
-  template < typename Range = Derived,
-             concepts::Requires< false, concepts::IsRandomAccessIterator,
-                                 typename Range::iterator > = true >
-  constexpr decltype(auto) at( std::size_t i ) const {
-
-    static_assert( 
-      concepts::IsRandomAccessIterator< typename Range::iterator >::value == true, 
-      "the at() method can only be made available for random access iterators" );
-    return typename Derived::value_type{};
   }
 };
 

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -2,7 +2,6 @@
 #define NJOY_TOOLS_RANGES_VIEWBASE
 
 // system includes
-#include <cassert>
 #include <stdexcept>
 
 // other includes
@@ -46,7 +45,6 @@ public:
                                  typename Range::iterator > = true >
   constexpr decltype(auto) front() const noexcept {
 
-    assert( ( !this->empty(), "front(): view is empty" ) );
     return *( this->derived().begin() );
   }
 
@@ -58,7 +56,6 @@ public:
                                  typename Range::iterator > = true >
   constexpr decltype(auto) back() const noexcept {
 
-    assert( ( !this->empty(), "back(): view is empty" ) );
     return *( std::prev( this->derived().end() ) );
   }
 

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -154,6 +154,85 @@ public:
 
     return !this->operator==( other );
   }
+
+  // the following code is added to make compiler errors more comprehensible
+
+  template < typename Range = Derived,
+             concepts::Requires< false, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
+  constexpr bool empty() const noexcept {
+
+    static_assert( 
+      concepts::IsForwardIterator< typename Range::iterator >::value == true, 
+      "the empty() method can only be made available for forward iterators" );
+    return true;
+  }
+
+  template < typename Range = Derived,
+             concepts::Requires< false, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
+  constexpr explicit operator bool() const noexcept {
+
+    static_assert( 
+      concepts::IsForwardIterator< typename Range::iterator >::value == true, 
+      "the operator bool() method can only be made available for forward iterators" );
+    return true;
+  }
+
+  template < typename Range = Derived,
+             concepts::Requires< false, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
+  constexpr std::size_t size() const noexcept {
+
+    static_assert( 
+      concepts::IsForwardIterator< typename Range::iterator >::value == true, 
+      "the size() method can only be made available for forward iterators" );
+    return std::size_t{};
+  }
+
+  template < typename Range = Derived,
+             concepts::Requires< false, concepts::IsForwardIterator,
+                                 typename Range::iterator > = true >
+  constexpr decltype(auto) front() const noexcept {
+
+    static_assert( 
+      concepts::IsBidirectionalIterator< typename Range::iterator >::value == true, 
+      "the front() method can only be made available for bidirectional iterators" );
+    return typename Derived::value_type{};
+  }
+
+  template < typename Range = Derived,
+             concepts::Requires< false, concepts::IsBidirectionalIterator,
+                                 typename Range::iterator > = true >
+  constexpr decltype(auto) back() const noexcept {
+
+    static_assert( 
+      concepts::IsBidirectionalIterator< typename Range::iterator >::value == true, 
+      "the back() method can only be made available for bidirectional iterators" );
+    return typename Derived::value_type{};
+  }
+
+  template < typename Range = Derived,
+             concepts::Requires< false, concepts::IsRandomAccessIterator,
+                                 typename Range::iterator > = true >
+  constexpr decltype(auto) operator[]( std::size_t i ) const {
+
+    static_assert( 
+      concepts::IsRandomAccessIterator< typename Range::iterator >::value == true, 
+      "the operator[] method can only be made available for random access iterators" );
+    return typename Derived::value_type{};
+  }
+
+  template < typename Range = Derived,
+             concepts::Requires< false, concepts::IsRandomAccessIterator,
+                                 typename Range::iterator > = true >
+  constexpr decltype(auto) at( std::size_t i ) const {
+
+    static_assert( 
+      concepts::IsRandomAccessIterator< typename Range::iterator >::value == true, 
+      "the at() method can only be made available for random access iterators" );
+    return typename Derived::value_type{};
+  }
 };
 
 } // ranges namespace

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -52,7 +52,7 @@ public:
    *  @brief Return the reference to the back element of the view
    */
   template < typename Range = Derived,
-             concepts::Requires< true, concepts::IsForwardIterator,
+             concepts::Requires< true, concepts::IsBidirectionalIterator,
                                  typename Range::iterator > = true >
   constexpr decltype(auto) back() const noexcept {
 

--- a/src/tools/ranges/ViewBase.hpp
+++ b/src/tools/ranges/ViewBase.hpp
@@ -120,7 +120,10 @@ public:
    *
    *  @param[in] other    the other container to compare with
    */
-  template < typename Container >
+  template < typename Container,
+             typename Range = Derived,
+             concepts::Requires< true, concepts::IsInputIterator,
+                                 typename Range::iterator > = true >
   constexpr bool operator==( const Container& other ) const {
 
     return std::equal( this->derived().begin(), this->derived().end(),
@@ -132,7 +135,10 @@ public:
    *
    *  @param[in] other    the other container to compare with
    */
-  template < typename Container >
+  template < typename Container,
+             typename Range = Derived,
+             concepts::Requires< true, concepts::IsInputIterator,
+                                 typename Range::iterator > = true >
   constexpr bool operator!=( const Container& other ) const {
 
     return !this->operator==( other );

--- a/src/tools/ranges/concepts.hpp
+++ b/src/tools/ranges/concepts.hpp
@@ -1,0 +1,3 @@
+#include "tools/concepts/Requires.hpp"
+
+#include "tools/concepts/IsRange.hpp"

--- a/src/tools/ranges/make_view/test/make_view.test.cpp
+++ b/src/tools/ranges/make_view/test/make_view.test.cpp
@@ -14,6 +14,57 @@ using namespace njoy::tools::ranges;
 
 SCENARIO( "make_view" ) {
 
+  GIVEN( "a container with forward iterators" ) {
+
+    std::forward_list< int > values = { -2, -1, 0, 1, 2 };
+
+    WHEN( "when using iterators" ) {
+
+      auto chunk = make_view( values.begin(), values.end() );
+
+      THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
+
+        CHECK( 5 == chunk.size() );
+        CHECK( false == chunk.empty() );
+
+        // the following should not compile: no random access iterator
+        // CHECK( -2 == chunk[0] );
+        // CHECK( -2 == chunk.at(0) );
+
+        CHECK( -2 == chunk.front() );
+
+        // the following should not compile: no bidirectional iterator
+        // CHECK(  2 == chunk.back() );
+      } // THEN
+    } // WHEN
+
+    WHEN( "when using the container" ) {
+
+      auto chunk = make_view( values );
+
+      THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
+
+        CHECK( 5 == chunk.size() );
+        CHECK( false == chunk.empty() );
+
+        // the following should not compile: no random access iterator
+        // CHECK( -2 == chunk[0] );
+        // CHECK( -2 == chunk.at(0) );
+
+        CHECK( -2 == chunk.front() );
+
+        // the following should not compile: no bidirectional iterator
+        // CHECK(  2 == chunk.back() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
   GIVEN( "a container with bidirectional iterators" ) {
 
     std::list< int > values = { -2, -1, 0, 1, 2 };

--- a/src/tools/ranges/make_view/test/make_view.test.cpp
+++ b/src/tools/ranges/make_view/test/make_view.test.cpp
@@ -5,13 +5,63 @@
 #include "tools/ranges/make_view.hpp"
 
 // other includes
+#include <forward_list>
+#include <list>
+#include <vector>
 
 // convenience typedefs
 using namespace njoy::tools::ranges;
 
 SCENARIO( "make_view" ) {
 
-  GIVEN( "a container with values" ) {
+  GIVEN( "a container with bidirectional iterators" ) {
+
+    std::list< int > values = { -2, -1, 0, 1, 2 };
+
+    WHEN( "when using iterators" ) {
+
+      auto chunk = make_view( values.begin(), values.end() );
+
+      THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
+
+        CHECK( 5 == chunk.size() );
+        CHECK( false == chunk.empty() );
+
+        // the following should not compile: no random access iterator
+        // CHECK( -2 == chunk[0] );
+        // CHECK( -2 == chunk.at(0) );
+
+        CHECK( -2 == chunk.front() );
+        CHECK(  2 == chunk.back() );
+      } // THEN
+    } // WHEN
+
+    WHEN( "when using the container" ) {
+
+      auto chunk = make_view( values );
+
+      THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
+
+        CHECK( 5 == chunk.size() );
+        CHECK( false == chunk.empty() );
+
+        // the following should not compile: no random access iterator
+        // CHECK( -2 == chunk[0] );
+        // CHECK( -2 == chunk.at(0) );
+
+        CHECK( -2 == chunk.front() );
+        CHECK(  2 == chunk.back() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "a container with random access iterators" ) {
 
     std::vector< int > values = { -2, -1, 0, 1, 2 };
 
@@ -20,6 +70,9 @@ SCENARIO( "make_view" ) {
       auto chunk = make_view( values.begin(), values.end() );
 
       THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
@@ -46,6 +99,9 @@ SCENARIO( "make_view" ) {
       auto chunk = make_view( values );
 
       THEN( "an IteratorView can be constructed and members can be tested" ) {
+
+        CHECK( values.begin() == chunk.begin() );
+        CHECK( values.end() == chunk.end() );
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );

--- a/src/tools/ranges/make_view/test/make_view.test.cpp
+++ b/src/tools/ranges/make_view/test/make_view.test.cpp
@@ -29,6 +29,7 @@ SCENARIO( "make_view" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         // the following should not compile: no random access iterator
         // CHECK( -2 == chunk[0] );
@@ -52,6 +53,7 @@ SCENARIO( "make_view" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         // the following should not compile: no random access iterator
         // CHECK( -2 == chunk[0] );
@@ -80,6 +82,7 @@ SCENARIO( "make_view" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         // the following should not compile: no random access iterator
         // CHECK( -2 == chunk[0] );
@@ -101,6 +104,7 @@ SCENARIO( "make_view" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         // the following should not compile: no random access iterator
         // CHECK( -2 == chunk[0] );
@@ -127,6 +131,7 @@ SCENARIO( "make_view" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         CHECK( -2 == chunk[0] );
         CHECK( -1 == chunk[1] );
@@ -156,6 +161,7 @@ SCENARIO( "make_view" ) {
 
         CHECK( 5 == chunk.size() );
         CHECK( false == chunk.empty() );
+        CHECK( false == bool( chunk ) );
 
         CHECK( -2 == chunk[0] );
         CHECK( -1 == chunk[1] );


### PR DESCRIPTION
This PR introduces a number of sfinae structures and aliases related to iterators and ranges.

This PR also introduces a ViewBase CRTP base class for views using these sfinae structures and aliases. The ViewBase assumes that the Derived class has a Derived::iterator type, a begin() and end() iterator. All methods with the exception of begin() and end() are made available depending on the type of the Derived::iterator type:
- if Derived::iterator satisfies concepts::IsInputIterator: operator== and operator!=
- if Derived::iterator satisfies concepts::IsForwardIterator: front(), size(), empty() and operator bool()
- if Derived::iterator satisfies concepts::IsBidirectionalIterator: back()
- if Derived::iterator satisfies concepts::IsRandomAccessIterator: operator[] and at()

The ViewBase interface should satisfy the C++20 view_interface, with the exception of data() which requires contiguous iterators (a concept introduced in C++20).

The ViewBase is now applied as the base class for the IteratorView which previously could only be used for random access iterators. It can now be used for all iterator types and the interface will be made available based on the underlying iterator type.