### PR TITLE
Feature/std23 chunk

### DIFF
--- a/src/tools/std23/views.hpp
+++ b/src/tools/std23/views.hpp
@@ -1,2 +1,2 @@
+#include "tools/std23/views/chunk.hpp"
 #include "tools/std23/views/chunk_by.hpp"
-

--- a/src/tools/std23/views/chunk.hpp
+++ b/src/tools/std23/views/chunk.hpp
@@ -149,9 +149,17 @@ private:
       return *this += -n;
     }
 
-    template < typename B = Base >
-    constexpr auto operator[]( difference_type n ) const
-    -> std::enable_if_t< std20::ranges::random_access_range< B >, value_type > {
+    // this version of operator[] does not work on gcc
+    // template < typename B = Base >
+    // constexpr auto operator[]( difference_type n ) const
+    // -> std::enable_if_t< std20::ranges::random_access_range< B >, value_type > {
+    //
+    //   return *( *this + n );
+    // }
+
+    template < typename B = Base,
+               typename = std::enable_if_t< std20::ranges::random_access_range< B > > >
+    constexpr decltype(auto) operator[]( difference_type n ) const {
 
       return *( *this + n );
     }

--- a/src/tools/std23/views/chunk.hpp
+++ b/src/tools/std23/views/chunk.hpp
@@ -1,0 +1,316 @@
+#ifndef NJOY_TOOLS_STD23_RANGES_VIEWS_CHUNK
+#define NJOY_TOOLS_STD23_RANGES_VIEWS_CHUNK
+
+#include "tools/std20/detail/views/range_adaptors.hpp"
+#include "tools/std20/views/interface.hpp"
+#include "tools/std20/views/all.hpp"
+#include "tools/std20/views/subrange.hpp"
+#include "tools/std20/views/take.hpp"
+
+namespace njoy {
+namespace tools {
+namespace std23 {
+inline namespace ranges {
+
+template < class Integer >
+constexpr Integer div_ceil( Integer num, Integer denom ) {
+
+  Integer r = num / denom;
+  if ( num % denom ) {
+
+    ++r;
+  }
+  return r;
+}
+
+/**
+ *  @brief A range adaptor that takes a view and a number n and produces a
+ *         range of views such that each chunk, except maybe the last one, has the size n
+ *
+ *  See https://en.cppreference.com/w/cpp/ranges/chunk_view
+ */
+template < typename R >
+struct chunk_view : std20::ranges::view_interface< chunk_view< R > > {
+
+  static_assert( std20::ranges::view< R > );
+  static_assert( std20::ranges::forward_range< R > );
+
+private:
+
+  R base_;
+  std20::ranges::range_difference_t< R > n_;
+
+  template < bool Const >
+  struct iterator {
+
+  private:
+
+    friend chunk_view;
+
+    using Parent = std20::ranges::detail::conditional_t< Const, const chunk_view, chunk_view >;
+    using Base = std20::ranges::detail::conditional_t< Const, const R, R >;
+
+    chunk_view* parent_ = nullptr;
+    std20::ranges::iterator_t< Base > current_ = std20::ranges::iterator_t< Base >();
+    std20::ranges::iterator_t< Base > end_ = std20::ranges::iterator_t< Base >();
+    std20::ranges::range_difference_t< Base > n_ = 0;
+    std20::ranges::range_difference_t< Base > missing_ = 0;
+
+    constexpr iterator( Parent* parent, std20::ranges::iterator_t< Base > current,
+                        std20::ranges::range_difference_t< Base > missing = 0 ) :
+        current_( std::move( current ) ),
+        end_( std20::ranges::end( parent->base_ ) ),
+        n_( parent->n_ ),
+        missing_( missing ) {}
+
+  public:
+
+    using value_type        = decltype( std20::views::take( std20::ranges::subrange( current_, end_ ), n_ ) );
+    using difference_type   = std20::ranges::range_difference_t< R >;
+    using iterator_category = std::conditional_t<
+                                  std20::ranges::random_access_range< R >,
+                                  std20::random_access_iterator_tag,
+                                  std::conditional_t< std20::ranges::bidirectional_range< R >,
+                                                  std20::bidirectional_iterator_tag,
+                                                  std20::forward_iterator_tag > >;
+
+    iterator() = default;
+
+    template < typename Iterator,
+               std::enable_if_t< std20::same_as< Iterator, iterator< ! Const > >, int > = 0,
+               bool C = Const, typename RR = R,
+               std::enable_if_t< C && std20::convertible_to< std20::ranges::iterator_t< RR >,
+                                                             std20::ranges::iterator_t< Base > >, int > = 0 >
+    constexpr iterator( Iterator iter ) :
+        current_( std::move( iter.current_ ) ),
+        end_( std::move( iter.end_ ) ),
+        n_( iter.n_ ),
+        missing_( iter.missing_ ) {}
+
+    constexpr std20::ranges::iterator_t< Base > base() const { return this->current_; }
+
+    constexpr value_type operator*() const {
+
+      return std20::views::take( std20::ranges::subrange( this->current_, this->end_ ), this->n_ );
+    }
+
+    constexpr iterator& operator++() {
+
+      this->missing_ = std20::ranges::advance( this->current_, this->n_, this->end_ );
+      return *this;
+    }
+
+    constexpr iterator operator++(int) {
+
+      auto temp = *this;
+      ++*this;
+      return temp;
+    }
+
+    template < typename B = Base >
+    constexpr auto operator--()
+    -> std::enable_if_t< std20::ranges::bidirectional_range< B >, iterator& > {
+
+      std20::ranges::advance( this->current_, this->missing_ - this->n_ );
+      this->missing_ = 0;
+      return *this;
+    }
+
+    template < typename B = Base >
+    constexpr auto operator--(int)
+    -> std::enable_if_t< std20::ranges::bidirectional_range< B >, iterator > {
+
+      auto temp = *this;
+      --*this;
+      return temp;
+    }
+
+    template < typename B = Base >
+    constexpr auto operator+=( difference_type n )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, iterator& > {
+
+      if ( n > 0 ) {
+
+        std20::ranges::advance( this->current_, this->n_ * ( n - 1 ) );
+        this->missing_ = std20::ranges::advance( this->current_, this->n_, this->end_ );
+      }
+      else if ( n < 0 ) {
+
+        std20::ranges::advance( this->current_, this->n_ * n + this->missing_ );
+        this->missing_ = 0;
+      }
+      return *this;
+    }
+
+    template < typename B = Base >
+    constexpr auto operator-=( difference_type n )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, iterator& > {
+
+      return *this += -n;
+    }
+
+    template < typename B = Base >
+    constexpr auto operator[]( difference_type n ) const
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, value_type > {
+
+      return *( *this + n );
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator==( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::equality_comparable< std20::ranges::iterator_t< B > >, bool > {
+
+      return left.current_ == right.current_;
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator!=( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::equality_comparable< std20::ranges::iterator_t< B > >, bool > {
+
+      return ! ( left == right );
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator<( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, bool > {
+
+      return left.current_ < right.current_;
+    }
+
+    template <typename B = Base>
+    friend constexpr auto operator>( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, bool > {
+
+      return right < left;
+    }
+
+    template <typename B = Base>
+    friend constexpr auto operator<=( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, bool > {
+
+      return ! ( right < left );
+    }
+
+    template <typename B = Base>
+    friend constexpr auto operator>=( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, bool > {
+
+        return ! ( left < right );
+    }
+
+  };
+
+public:
+
+  chunk_view() = default;
+
+  constexpr chunk_view( R base, std20::ranges::range_difference_t< R > n ) :
+      base_( std::move( base ) ), n_( n ) {
+
+    assert( this->n_ > 0 );
+  }
+
+  constexpr R base() const { return base_; }
+
+  constexpr iterator< false > begin() {
+
+    return { this, std20::ranges::begin( this->base_ ) };
+  }
+
+  constexpr iterator< true > begin() const {
+
+    return { this, std20::ranges::begin( this->base_ ) };
+  }
+
+  constexpr iterator< false > end() {
+
+    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R >) {
+
+      auto missing = ( this->n_ - std20::ranges::distance( this->base_ ) % this->n_ ) % this->n_;
+      return iterator< false >( this, std20::ranges::end( this->base_ ), missing );
+    }
+    else if constexpr ( std20::ranges::common_range< R > && ! std20::ranges::bidirectional_range< R >) {
+
+      return iterator< false >( this, std20::ranges::end( this->base_ ) );
+    }
+    else {
+
+      return std20::ranges::default_sentinel;
+    }
+  }
+
+  constexpr iterator< true > end() const {
+
+    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R >) {
+
+      auto missing = ( this->n_ - std20::ranges::distance( this->base_ ) % this->n_ ) % this->n_;
+      return iterator< true >( this, std20::ranges::end( this->base_ ), missing );
+    }
+    else if constexpr ( std20::ranges::common_range< R > && ! std20::ranges::bidirectional_range< R >) {
+
+      return iterator< true >( this, std20::ranges::end( this->base_ ) );
+    }
+    else {
+
+      return std20::ranges::default_sentinel;
+    }
+  }
+
+  template < typename B = R >
+  constexpr auto size()
+  -> std::enable_if_t< std20::ranges::sized_range< B >, std::size_t > {
+
+    return div_ceil( std20::ranges::distance( this->base_ ), this->n_ );
+  }
+
+  template < typename B = R >
+  constexpr auto size() const
+  -> std::enable_if_t< std20::ranges::sized_range< B >, std::size_t > {
+
+    return div_ceil( std20::ranges::distance( this->base_ ), this->n_ );
+  }
+
+};
+
+template < typename R >
+chunk_view( R&&, std20::ranges::range_difference_t< R > ) -> chunk_view< std20::ranges::all_view< R > >;
+
+namespace detail {
+
+struct chunk_view_fn {
+
+    template < typename E, typename F >
+    constexpr auto operator()( E&& e, F&& f ) const
+    -> decltype( chunk_view{ std::forward< E >( e ), std::forward< F >( f ) } )
+    {
+        return chunk_view{ std::forward< E >( e ), std::forward< F >( f ) };
+    }
+
+    template < typename C >
+    constexpr auto operator()( C&& c ) const
+    {
+        return std20::ranges::detail::rao_proxy{ [p = std::forward< C >( c ) ] ( auto&& r ) mutable
+#ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND
+            -> decltype( chunk_view{ std::forward< decltype(r) >( r ), std::declval< C&& >() } )
+#endif
+        {
+            return chunk_view{ std::forward< decltype(r) >( r ), std::move( p ) };
+        }};
+    }
+
+};
+
+}
+
+namespace views {
+
+NANO_INLINE_VAR(ranges::detail::chunk_view_fn, chunk)
+
+}
+
+} // namespace ranges
+} // namespace std23
+} // namespace tools
+} // namespace njoy
+
+#endif

--- a/src/tools/std23/views/chunk.hpp
+++ b/src/tools/std23/views/chunk.hpp
@@ -177,27 +177,77 @@ private:
       return left.current_ < right.current_;
     }
 
-    template <typename B = Base>
+    template < typename B = Base>
     friend constexpr auto operator>( const iterator& left, const iterator& right )
     -> std::enable_if_t< std20::ranges::random_access_range< B >, bool > {
 
       return right < left;
     }
 
-    template <typename B = Base>
+    template < typename B = Base >
     friend constexpr auto operator<=( const iterator& left, const iterator& right )
     -> std::enable_if_t< std20::ranges::random_access_range< B >, bool > {
 
       return ! ( right < left );
     }
 
-    template <typename B = Base>
+    template < typename B = Base >
     friend constexpr auto operator>=( const iterator& left, const iterator& right )
     -> std::enable_if_t< std20::ranges::random_access_range< B >, bool > {
 
         return ! ( left < right );
     }
 
+    template < typename B = Base >
+    friend constexpr auto operator+( const iterator& left, const difference_type n )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, iterator > {
+
+      return iterator{ left } += n;
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator+( const difference_type n, const iterator& right )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, iterator > {
+
+      return right + n;
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator-( const iterator& left, const difference_type n )
+    -> std::enable_if_t< std20::ranges::random_access_range< B >, iterator > {
+
+      return iterator{ left } -= n;
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator-( const iterator& left, const iterator& right )
+    -> std::enable_if_t<
+        std20::ranges::sized_sentinel_for< std20::ranges::iterator_t< B >,
+                                           std20::ranges::iterator_t< B > >,
+        difference_type > {
+
+      return ( left.current_ - right.current_ + left.missing_ - right.missing_ ) / left.n_;
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator-( const std20::ranges::default_sentinel_t, const iterator& right )
+    -> std::enable_if_t<
+        std20::ranges::sized_sentinel_for< std20::ranges::sentinel_t< B >,
+                                           std20::ranges::iterator_t< B > >,
+        difference_type > {
+
+      return div_ceil( right.end_ - right.current_, right.n_ );
+    }
+
+    template < typename B = Base >
+    friend constexpr auto operator-( const iterator& left, const std20::ranges::default_sentinel_t right )
+    -> std::enable_if_t<
+        std20::ranges::sized_sentinel_for< std20::ranges::sentinel_t< B >,
+                                           std20::ranges::iterator_t< B > >,
+        difference_type > {
+
+      return -( right - left );
+    }
   };
 
 public:

--- a/src/tools/std23/views/chunk.hpp
+++ b/src/tools/std23/views/chunk.hpp
@@ -66,11 +66,11 @@ private:
   public:
 
     using value_type        = decltype( std20::views::take( std20::ranges::subrange( current_, end_ ), n_ ) );
-    using difference_type   = std20::ranges::range_difference_t< R >;
+    using difference_type   = std20::ranges::range_difference_t< Base >;
     using iterator_category = std::conditional_t<
-                                  std20::ranges::random_access_range< R >,
+                                  std20::ranges::random_access_range< Base >,
                                   std20::random_access_iterator_tag,
-                                  std::conditional_t< std20::ranges::bidirectional_range< R >,
+                                  std::conditional_t< std20::ranges::bidirectional_range< Base >,
                                                   std20::bidirectional_iterator_tag,
                                                   std20::forward_iterator_tag > >;
 

--- a/src/tools/std23/views/chunk_by.hpp
+++ b/src/tools/std23/views/chunk_by.hpp
@@ -78,32 +78,37 @@ private:
       return temp;
     }
 
-    template < typename RR = R,
-               typename = std::enable_if_t< std20::ranges::bidirectional_range< RR > > >
-    constexpr iterator& operator--() {
+    template < typename B = R >
+    constexpr auto operator--()
+    -> std::enable_if_t< std20::ranges::bidirectional_range< B >, iterator& > {
+
 
       this->next_ = this->current_;
       this->current_ = this->parent_->find_prev( this->next_ );
       return *this;
     }
 
-    template < typename RR = R,
-               typename = std::enable_if_t< std20::ranges::bidirectional_range< RR > > >
-    constexpr iterator operator--(int) {
+    template < typename B = R >
+    constexpr auto operator--(int)
+    -> std::enable_if_t< std20::ranges::bidirectional_range< B >, iterator > {
 
       auto temp = *this;
       --*this;
       return temp;
     }
 
-    constexpr bool operator==( const iterator& right ) const {
+    template < typename B = R >
+    friend constexpr auto operator==( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::equality_comparable< std20::ranges::iterator_t< B > >, bool > {
 
-      return this->current_ == right.current_;
+      return left.current_ == right.current_;
     }
 
-    constexpr bool operator!=( const iterator& right ) const {
+    template < typename B = R >
+    friend constexpr auto operator!=( const iterator& left, const iterator& right )
+    -> std::enable_if_t< std20::equality_comparable< std20::ranges::iterator_t< B > >, bool > {
 
-      return !( this->operator==( right ) );
+      return ! ( left == right );
     }
   };
 

--- a/src/tools/std23/views/test/CMakeLists.txt
+++ b/src/tools/std23/views/test/CMakeLists.txt
@@ -1,2 +1,2 @@
+add_cpp_test( std23.views.chunk chunk.test.cpp )
 add_cpp_test( std23.views.chunk_by chunk_by.test.cpp )
-

--- a/src/tools/std23/views/test/chunk.test.cpp
+++ b/src/tools/std23/views/test/chunk.test.cpp
@@ -1,0 +1,89 @@
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+
+// what we are testing
+#include "tools/std23/views.hpp"
+
+// other includes
+#include <forward_list>
+#include <list>
+#include <vector>
+#include "tools/std20/algorithm.hpp"
+
+// convenience typedefs
+using namespace njoy::tools;
+
+SCENARIO( "chunk_by_view" ) {
+
+  const std::vector< std::vector< int > > equal = { { 1, 2, 3 }, { 4, 5, 6 }, { 7, 8, 9 } };
+
+  GIVEN( "a container with random access iterators" ) {
+
+    std::vector< int > values = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    WHEN( "when iterators are used" ) {
+
+      auto chunk = values | std23::views::chunk( 3 );
+      using Range = decltype(chunk);
+      using Iterator = std20::iterator_t< Range >;
+      using Subrange = decltype(chunk.front());
+
+      THEN( "the chunk_by_view satisfies the required concepts" ) {
+
+        CHECK( std20::ranges::range< Range > );
+        CHECK( std20::ranges::view< Range > );
+        CHECK( std20::ranges::sized_range< Range > );
+        CHECK( std20::ranges::forward_range< Range > );
+        CHECK( std20::ranges::bidirectional_range< Range > );
+//        CHECK( std20::ranges::random_access_range< Range > );
+        CHECK( ! std20::ranges::contiguous_range< Range > );
+        CHECK( std20::ranges::common_range< Range > );
+      }
+
+      THEN( "a chunk_by_view can be constructed and members can be tested" ) {
+
+        CHECK( 3 == chunk.size() );
+
+        CHECK( false == chunk.empty() );
+        CHECK( true == bool( chunk ) );
+
+        auto iter = chunk.begin();
+        CHECK( std20::ranges::equal( equal[0], *iter ) );
+        CHECK( 1 == (*iter)[0] );
+        CHECK( 2 == (*iter)[1] );
+        CHECK( 3 == (*iter)[2] );
+        ++iter;
+        CHECK( std20::ranges::equal( equal[1], *iter ) );
+        CHECK( 4 == (*iter)[0] );
+        CHECK( 5 == (*iter)[1] );
+        CHECK( 6 == (*iter)[2] );
+        ++iter;
+        CHECK( std20::ranges::equal( equal[2], *iter ) );
+        CHECK( 7 == (*iter)[0] );
+        CHECK( 8 == (*iter)[1] );
+        CHECK( 9 == (*iter)[2] );
+
+        iter = chunk.end();
+        --iter;
+        CHECK( std20::ranges::equal( equal[2], *iter ) );
+        CHECK( 7 == (*iter)[0] );
+        CHECK( 8 == (*iter)[1] );
+        CHECK( 9 == (*iter)[2] );
+        --iter;
+        CHECK( std20::ranges::equal( equal[1], *iter ) );
+        CHECK( 4 == (*iter)[0] );
+        CHECK( 5 == (*iter)[1] );
+        CHECK( 6 == (*iter)[2] );
+        --iter;
+        CHECK( std20::ranges::equal( equal[0], *iter ) );
+        CHECK( 1 == (*iter)[0] );
+        CHECK( 2 == (*iter)[1] );
+        CHECK( 3 == (*iter)[2] );
+        CHECK( chunk.begin() == iter );
+
+        CHECK( std20::ranges::equal( equal[0], chunk.front() ) );
+        CHECK( std20::ranges::equal( equal[2], chunk.back() ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO

--- a/src/tools/std23/views/test/chunk.test.cpp
+++ b/src/tools/std23/views/test/chunk.test.cpp
@@ -17,6 +17,98 @@ SCENARIO( "chunk_by_view" ) {
 
   const std::vector< std::vector< int > > equal = { { 1, 2, 3 }, { 4, 5, 6 }, { 7, 8, 9 } };
 
+  GIVEN( "a container with forward iterators" ) {
+
+    std::forward_list< int > values = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    WHEN( "when iterators are used" ) {
+
+      auto chunk = values | std23::views::chunk( 3 );
+      using Range = decltype(chunk);
+      using Iterator = std20::iterator_t< Range >;
+      using Subrange = decltype(chunk.front());
+
+      THEN( "the chunk_by_view satisfies the required concepts" ) {
+
+        CHECK( std20::ranges::range< Range > );
+        CHECK( std20::ranges::view< Range > );
+        CHECK( ! std20::ranges::sized_range< Range > );
+        CHECK( std20::ranges::forward_range< Range > );
+        CHECK( ! std20::ranges::bidirectional_range< Range > );
+        CHECK( ! std20::ranges::random_access_range< Range > );
+        CHECK( ! std20::ranges::contiguous_range< Range > );
+        CHECK( std20::ranges::common_range< Range > );
+      }
+
+      THEN( "a chunk_by_view can be constructed and members can be tested" ) {
+
+        CHECK( false == chunk.empty() );
+        CHECK( true == bool( chunk ) );
+
+        auto iter = chunk.begin();
+        CHECK( std20::ranges::equal( equal[0], *iter ) );
+        ++iter;
+        CHECK( std20::ranges::equal( equal[1], *iter ) );
+        ++iter;
+        CHECK( std20::ranges::equal( equal[2], *iter ) );
+
+        CHECK( std20::ranges::equal( equal[0], chunk.front() ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "a container with bidirectional iterators" ) {
+
+    std::list< int > values = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    WHEN( "when iterators are used" ) {
+
+      auto chunk = values | std23::views::chunk( 3 );
+      using Range = decltype(chunk);
+      using Iterator = std20::iterator_t< Range >;
+      using Subrange = decltype(chunk.front());
+
+      THEN( "the chunk_by_view satisfies the required concepts" ) {
+
+        CHECK( std20::ranges::range< Range > );
+        CHECK( std20::ranges::view< Range > );
+        CHECK( std20::ranges::sized_range< Range > );
+        CHECK( std20::ranges::forward_range< Range > );
+        CHECK( std20::ranges::bidirectional_range< Range > );
+        CHECK( ! std20::ranges::random_access_range< Range > );
+        CHECK( ! std20::ranges::contiguous_range< Range > );
+        CHECK( std20::ranges::common_range< Range > );
+      }
+
+      THEN( "a chunk_by_view can be constructed and members can be tested" ) {
+
+        CHECK( 3 == chunk.size() );
+
+        CHECK( false == chunk.empty() );
+        CHECK( true == bool( chunk ) );
+
+        auto iter = chunk.begin();
+        CHECK( std20::ranges::equal( equal[0], *iter ) );
+        ++iter;
+        CHECK( std20::ranges::equal( equal[1], *iter ) );
+        ++iter;
+        CHECK( std20::ranges::equal( equal[2], *iter ) );
+
+        iter = chunk.end();
+        --iter;
+        CHECK( std20::ranges::equal( equal[2], *iter ) );
+        --iter;
+        CHECK( std20::ranges::equal( equal[1], *iter ) );
+        --iter;
+        CHECK( std20::ranges::equal( equal[0], *iter ) );
+        CHECK( chunk.begin() == iter );
+
+        CHECK( std20::ranges::equal( equal[0], chunk.front() ) );
+        CHECK( std20::ranges::equal( equal[2], chunk.back() ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
   GIVEN( "a container with random access iterators" ) {
 
     std::vector< int > values = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -35,7 +127,7 @@ SCENARIO( "chunk_by_view" ) {
         CHECK( std20::ranges::sized_range< Range > );
         CHECK( std20::ranges::forward_range< Range > );
         CHECK( std20::ranges::bidirectional_range< Range > );
-//        CHECK( std20::ranges::random_access_range< Range > );
+        CHECK( std20::ranges::random_access_range< Range > );
         CHECK( ! std20::ranges::contiguous_range< Range > );
         CHECK( std20::ranges::common_range< Range > );
       }
@@ -83,6 +175,16 @@ SCENARIO( "chunk_by_view" ) {
 
         CHECK( std20::ranges::equal( equal[0], chunk.front() ) );
         CHECK( std20::ranges::equal( equal[2], chunk.back() ) );
+
+        CHECK( 1 == chunk[0][0] );
+        CHECK( 2 == chunk[0][1] );
+        CHECK( 3 == chunk[0][2] );
+        CHECK( 4 == chunk[1][0] );
+        CHECK( 5 == chunk[1][1] );
+        CHECK( 6 == chunk[1][2] );
+        CHECK( 7 == chunk[2][0] );
+        CHECK( 8 == chunk[2][1] );
+        CHECK( 9 == chunk[2][2] );
       } // THEN
     } // WHEN
   } // GIVEN

--- a/src/tools/std23/views/test/chunk_by.test.cpp
+++ b/src/tools/std23/views/test/chunk_by.test.cpp
@@ -9,7 +9,6 @@
 #include <list>
 #include <vector>
 #include "tools/std20/algorithm.hpp"
-#include <iostream>
 
 // convenience typedefs
 using namespace njoy::tools;


### PR DESCRIPTION
In preparation for replacing range-v3 in ENDFtk, we need a few pieces defined in the c++23 standard: chunk, stride, zip, etc.

This adds the following:
  - std23::views::chunk (https://en.cppreference.com/w/cpp/ranges/chunk_view)
