### PR TITLE
Ensure our use cases work

### DIFF
--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -57,5 +57,7 @@ add_subdirectory( src/tools/std20/views/test )
 add_subdirectory( src/tools/std23/detail/views/test )
 add_subdirectory( src/tools/std23/views/test )
 
+add_subdirectory( src/tools/std23/test )
+
 add_subdirectory( src/tools/views/AnyIterator/test )
 add_subdirectory( src/tools/views/AnyView/test )

--- a/src/tools/std20/views/common.hpp
+++ b/src/tools/std20/views/common.hpp
@@ -103,6 +103,9 @@ public:
 template <typename R>
 common_view(R&&) -> common_view<all_view<R>>;
 
+template <class R>
+inline constexpr bool enable_borrowed_range<common_view<R>> = enable_borrowed_range<R>;
+
 namespace detail {
 
 struct common_view_fn {

--- a/src/tools/std20/views/drop.hpp
+++ b/src/tools/std20/views/drop.hpp
@@ -10,8 +10,7 @@
 #include "tools/std20/detail/views/range_adaptors.hpp"
 #include "tools/std20/views/all.hpp"
 #include "tools/std20/views/interface.hpp"
-
-#include <optional>
+#include "tools/std23/detail/views/nonpropagating_box.hpp"
 
 NANO_BEGIN_NAMESPACE
 
@@ -22,7 +21,7 @@ struct drop_view_cache {};
 
 template <typename I>
 struct drop_view_cache<false, I> {
-    std::optional<I> cached{};
+        std23::ranges::detail::nonpropagating_box<I> cached{};
 };
 
 }
@@ -52,7 +51,7 @@ struct drop_view
         } else {
             auto& c = this->cached;
             if (!c.has_value()) {
-                c = ranges::next(ranges::begin(base_), count_, ranges::end(base_));
+                c.emplace( ranges::next(ranges::begin(base_), count_, ranges::end(base_)) );
             }
             return *c;
         }

--- a/src/tools/std20/views/drop.hpp
+++ b/src/tools/std20/views/drop.hpp
@@ -100,6 +100,9 @@ private:
 template <typename R>
 drop_view(R&&, range_difference_t<R>) -> drop_view<all_view<R>>;
 
+template <typename R>
+inline constexpr bool enable_borrowed_range<drop_view<R>> = enable_borrowed_range<R>;
+
 namespace detail {
 
 struct drop_view_fn {

--- a/src/tools/std20/views/drop_while.hpp
+++ b/src/tools/std20/views/drop_while.hpp
@@ -59,6 +59,9 @@ private:
 template <typename R, typename Pred>
 drop_while_view(R&& r, Pred pred) -> drop_while_view<all_view<R>, Pred>;
 
+template <typename R, typename Pred>
+inline constexpr bool enable_borrowed_range<drop_while_view<R, Pred>> = enable_borrowed_range<R>;
+
 namespace detail {
 
 struct drop_while_view_fn {

--- a/src/tools/std20/views/elements.hpp
+++ b/src/tools/std20/views/elements.hpp
@@ -306,6 +306,9 @@ using keys_view = elements_view<all_view<R>, 0>;
 template <typename R>
 using values_view = elements_view<all_view<R>, 1>;
 
+template <class R, size_t N>
+inline constexpr bool enable_borrowed_range<elements_view<R, N>> = enable_borrowed_range<R>;
+
 namespace detail {
 
 template <std::size_t N>
@@ -337,7 +340,6 @@ inline constexpr ranges::detail::elements_view_fn<1> values{};
 }
 
 }
-
 
 NANO_END_NAMESPACE
 

--- a/src/tools/std20/views/take.hpp
+++ b/src/tools/std20/views/take.hpp
@@ -162,6 +162,9 @@ public:
 template <typename R, std::enable_if_t<range<R>, int> = 0>
 take_view(R&&, range_difference_t<R>) -> take_view<all_view<R>>;
 
+template <typename R>
+inline constexpr bool enable_borrowed_range<take_view<R>> = enable_borrowed_range<R>;
+
 namespace detail {
 
 #ifdef NANO_MSVC_LAMBDA_PIPE_WORKAROUND

--- a/src/tools/std23/test/CMakeLists.txt
+++ b/src/tools/std23/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_cpp_test( std23.usecase usecase.test.cpp )

--- a/src/tools/std23/test/usecase.test.cpp
+++ b/src/tools/std23/test/usecase.test.cpp
@@ -1,0 +1,190 @@
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+
+// what we are testing
+#include "tools/std20/views.hpp"
+#include "tools/std23/views.hpp"
+
+// other includes
+#include <vector>
+
+// convenience typedefs
+using namespace njoy::tools;
+
+class TestCase {
+ 
+  std::vector< double > vector_ = {  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
+                                    11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+
+public:
+
+  TestCase() = default;
+
+  auto iota() const {
+
+    using namespace njoy::tools;
+    return std20::views::iota( 20 );
+  }
+
+  auto iota_transform() const {
+
+    using namespace njoy::tools;
+    return this->iota() | std20::views::transform( [] ( auto&& value ) { return value + 1; } );
+  }
+
+  auto all() const {
+
+    using namespace njoy::tools;
+    return this->vector_ | std20::views::all;
+  }
+
+  auto transform() const {
+
+    using namespace njoy::tools;
+    return this->all() | std20::views::transform( [] ( auto&& value ) { return value + 1; } );
+  }
+
+  auto drop() const {
+
+    using namespace njoy::tools;
+    return this->all() | std20::views::drop( 2 );
+  }
+
+  auto stride() const {
+
+    using namespace njoy::tools;
+    return this->all() | std23::views::stride( 2 );
+  }
+
+  auto chunk() const {
+
+    using namespace njoy::tools;
+    return this->all() | std23::views::chunk( 2 );
+  }
+
+  auto drop_stride() const {
+
+    using namespace njoy::tools;
+    return this->all() | std20::views::drop( 2 ) 
+                       | std23::views::stride( 2 );
+  }
+
+  auto drop_chunk() const {
+
+    using namespace njoy::tools;
+    return this->all() | std20::views::drop( 2 ) 
+                       | std23::views::chunk( 2 );
+  }
+
+  auto stride_drop() const {
+
+    using namespace njoy::tools;
+    return this->all() | std23::views::stride( 2 ) 
+                       | std20::views::drop( 2 );
+  }
+
+  auto chunk_drop() const {
+
+    using namespace njoy::tools;
+    return this->all() | std23::views::chunk( 2 )
+                       | std20::views::drop( 2 );
+  }
+
+  auto chunk_stride() const {
+
+    using namespace njoy::tools;
+    return this->all() | std23::views::chunk( 2 ) 
+                       | std23::views::stride( 2 );
+  }
+
+  auto stride_chunk() const {
+
+    using namespace njoy::tools;
+    return this->all() | std23::views::stride( 2 ) 
+                       | std23::views::chunk( 2 );
+  }
+};
+
+SCENARIO( "use case" ) {
+
+  TestCase test;
+
+  using Iota = decltype( test.iota() );
+  CHECK( std20::view< Iota > );
+  CHECK( std20::range< Iota > );
+  CHECK( std20::random_access_range< Iota > );
+//  CHECK( std20::sized_range< Iota > );
+
+  using IotaTransform = decltype( test.iota_transform() );
+  CHECK( std20::view< IotaTransform > );
+  CHECK( std20::range< IotaTransform > );
+  CHECK( std20::random_access_range< IotaTransform > );
+//  CHECK( std20::sized_range< IotaTransform > );
+
+  using All = decltype( test.all() );
+  CHECK( std20::view< All > );
+  CHECK( std20::range< All > );
+  CHECK( std20::random_access_range< All > );
+  CHECK( std20::sized_range< All > );
+
+  using Transform = decltype( test.transform() );
+  CHECK( std20::view< Transform > );
+  CHECK( std20::range< Transform > );
+  CHECK( std20::random_access_range< Transform > );
+  CHECK( std20::sized_range< Transform > );
+
+  using Drop = decltype( test.drop() );
+  CHECK( std20::view< Drop > );
+  CHECK( std20::range< Drop > );
+  CHECK( std20::random_access_range< Drop > );
+  CHECK( std20::sized_range< Drop > );
+
+  using Stride = decltype( test.stride() );
+  CHECK( std20::view< Stride > );
+  CHECK( std20::range< Stride > );
+  CHECK( std20::random_access_range< Stride > );
+  CHECK( std20::sized_range< Stride > );
+
+  using Chunk = decltype( test.chunk() );
+  CHECK( std20::view< Chunk > );
+  CHECK( std20::range< Chunk > );
+  CHECK( std20::random_access_range< Chunk > );
+  CHECK( std20::sized_range< Chunk > );
+
+  using DropStride = decltype( test.drop_stride() );
+  CHECK( std20::view< DropStride > );
+  CHECK( std20::range< DropStride > );
+  CHECK( std20::random_access_range< DropStride > );
+  CHECK( std20::sized_range< DropStride > );
+
+  using DropChunk = decltype( test.drop_chunk() );
+  CHECK( std20::view< DropChunk > );
+  CHECK( std20::range< DropChunk > );
+  CHECK( std20::random_access_range< DropChunk > );
+  CHECK( std20::sized_range< DropChunk > );
+
+//  using StrideDrop = decltype( test.stride_drop() );
+//  CHECK( std20::view< StrideDrop > );
+//  CHECK( std20::range< StrideDrop > );
+//  CHECK( std20::random_access_range< StrideDrop > );
+//  CHECK( std20::sized_range< StrideDrop > );
+
+//  using ChunkDrop = decltype( test.chunk_drop() );
+//  CHECK( std20::view< ChunkDrop > );
+//  CHECK( std20::range< ChunkDrop > );
+//  CHECK( std20::random_access_range< ChunkDrop > );
+//  CHECK( std20::sized_range< ChunkDrop > );
+
+  using ChunkStride = decltype( test.chunk_stride() );
+  CHECK( std20::view< ChunkStride > );
+  CHECK( std20::range< ChunkStride > );
+  CHECK( std20::random_access_range< ChunkStride > );
+  CHECK( std20::sized_range< ChunkStride > );
+
+  using StrideChunk = decltype( test.stride_chunk() );
+  CHECK( std20::view< StrideChunk > );
+  CHECK( std20::range< StrideChunk > );
+  CHECK( std20::random_access_range< StrideChunk > );
+  CHECK( std20::sized_range< StrideChunk > );
+
+} // SCENARIO

--- a/src/tools/std23/test/usecase.test.cpp
+++ b/src/tools/std23/test/usecase.test.cpp
@@ -164,12 +164,16 @@ SCENARIO( "use case" ) {
   CHECK( std20::sized_range< DropChunk > );
 
 //  using StrideDrop = decltype( test.stride_drop() );
+//  auto begin = std20::ranges::begin( test.stride_drop() );
+//  auto end = std20::ranges::end( test.stride_drop() );
 //  CHECK( std20::view< StrideDrop > );
 //  CHECK( std20::range< StrideDrop > );
 //  CHECK( std20::random_access_range< StrideDrop > );
 //  CHECK( std20::sized_range< StrideDrop > );
 
 //  using ChunkDrop = decltype( test.chunk_drop() );
+//  auto begin1 = std20::ranges::begin( test.chunk_drop() );
+//  auto end1 = std20::ranges::end( test.chunk_drop() );
 //  CHECK( std20::view< ChunkDrop > );
 //  CHECK( std20::range< ChunkDrop > );
 //  CHECK( std20::random_access_range< ChunkDrop > );

--- a/src/tools/std23/test/usecase.test.cpp
+++ b/src/tools/std23/test/usecase.test.cpp
@@ -12,7 +12,7 @@
 using namespace njoy::tools;
 
 class TestCase {
- 
+
   std::vector< double > vector_ = {  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
                                     11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
 
@@ -65,21 +65,21 @@ public:
   auto drop_stride() const {
 
     using namespace njoy::tools;
-    return this->all() | std20::views::drop( 2 ) 
+    return this->all() | std20::views::drop( 2 )
                        | std23::views::stride( 2 );
   }
 
   auto drop_chunk() const {
 
     using namespace njoy::tools;
-    return this->all() | std20::views::drop( 2 ) 
+    return this->all() | std20::views::drop( 2 )
                        | std23::views::chunk( 2 );
   }
 
   auto stride_drop() const {
 
     using namespace njoy::tools;
-    return this->all() | std23::views::stride( 2 ) 
+    return this->all() | std23::views::stride( 2 )
                        | std20::views::drop( 2 );
   }
 
@@ -93,14 +93,14 @@ public:
   auto chunk_stride() const {
 
     using namespace njoy::tools;
-    return this->all() | std23::views::chunk( 2 ) 
+    return this->all() | std23::views::chunk( 2 )
                        | std23::views::stride( 2 );
   }
 
   auto stride_chunk() const {
 
     using namespace njoy::tools;
-    return this->all() | std23::views::stride( 2 ) 
+    return this->all() | std23::views::stride( 2 )
                        | std23::views::chunk( 2 );
   }
 };

--- a/src/tools/std23/test/usecase.test.cpp
+++ b/src/tools/std23/test/usecase.test.cpp
@@ -163,21 +163,17 @@ SCENARIO( "use case" ) {
   CHECK( std20::random_access_range< DropChunk > );
   CHECK( std20::sized_range< DropChunk > );
 
-//  using StrideDrop = decltype( test.stride_drop() );
-//  auto begin = std20::ranges::begin( test.stride_drop() );
-//  auto end = std20::ranges::end( test.stride_drop() );
-//  CHECK( std20::view< StrideDrop > );
-//  CHECK( std20::range< StrideDrop > );
-//  CHECK( std20::random_access_range< StrideDrop > );
-//  CHECK( std20::sized_range< StrideDrop > );
+  using StrideDrop = decltype( test.stride_drop() );
+  CHECK( std20::view< StrideDrop > );
+  CHECK( std20::range< StrideDrop > );
+  CHECK( std20::random_access_range< StrideDrop > );
+  CHECK( std20::sized_range< StrideDrop > );
 
-//  using ChunkDrop = decltype( test.chunk_drop() );
-//  auto begin1 = std20::ranges::begin( test.chunk_drop() );
-//  auto end1 = std20::ranges::end( test.chunk_drop() );
-//  CHECK( std20::view< ChunkDrop > );
-//  CHECK( std20::range< ChunkDrop > );
-//  CHECK( std20::random_access_range< ChunkDrop > );
-//  CHECK( std20::sized_range< ChunkDrop > );
+  using ChunkDrop = decltype( test.chunk_drop() );
+  CHECK( std20::view< ChunkDrop > );
+  CHECK( std20::range< ChunkDrop > );
+  CHECK( std20::random_access_range< ChunkDrop > );
+  CHECK( std20::sized_range< ChunkDrop > );
 
   using ChunkStride = decltype( test.chunk_stride() );
   CHECK( std20::view< ChunkStride > );

--- a/src/tools/std23/views/chunk.hpp
+++ b/src/tools/std23/views/chunk.hpp
@@ -334,6 +334,21 @@ public:
 template < typename R >
 chunk_view( R&&, std20::ranges::range_difference_t< R > ) -> chunk_view< std20::ranges::all_view< R > >;
 
+} // namespace ranges
+} // namespace std23
+
+namespace std20 {
+inline namespace ranges {
+
+template <typename R>
+inline constexpr bool enable_borrowed_range<std23::ranges::chunk_view<R>> = forward_range<R> && enable_borrowed_range<R>;
+
+} // namespace ranges
+} // namespace std20
+
+namespace std23 {
+inline namespace ranges {
+
 namespace detail {
 
 struct chunk_view_fn {

--- a/src/tools/std23/views/chunk.hpp
+++ b/src/tools/std23/views/chunk.hpp
@@ -319,16 +319,16 @@ public:
     }
   }
 
-  template < typename B = R >
+  template < typename RR = R >
   constexpr auto size()
-  -> std::enable_if_t< std20::ranges::sized_range< B >, std::size_t > {
+  -> std::enable_if_t< std20::ranges::sized_range< RR >, std::size_t > {
 
     return div_ceil( std20::ranges::distance( this->base_ ), this->n_ );
   }
 
-  template < typename B = R >
+  template < typename RR = R >
   constexpr auto size() const
-  -> std::enable_if_t< std20::ranges::sized_range< B >, std::size_t > {
+  -> std::enable_if_t< std20::ranges::sized_range< const RR >, std::size_t > {
 
     return div_ceil( std20::ranges::distance( this->base_ ), this->n_ );
   }

--- a/src/tools/std23/views/chunk.hpp
+++ b/src/tools/std23/views/chunk.hpp
@@ -271,16 +271,19 @@ public:
 
   constexpr R base() const { return base_; }
 
+  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0>
   constexpr iterator< false > begin() {
 
     return { this, std20::ranges::begin( this->base_ ) };
   }
 
+  template < typename RR = R, std::enable_if_t< std20::ranges::forward_range< const RR >, int > = 0 >
   constexpr iterator< true > begin() const {
 
     return { this, std20::ranges::begin( this->base_ ) };
   }
 
+  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0>
   constexpr iterator< false > end() {
 
     if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R >) {
@@ -298,6 +301,7 @@ public:
     }
   }
 
+  template < typename RR = R, std::enable_if_t< std20::ranges::forward_range< const RR >, int > = 0 >
   constexpr iterator< true > end() const {
 
     if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R >) {

--- a/src/tools/std23/views/chunk_by.hpp
+++ b/src/tools/std23/views/chunk_by.hpp
@@ -82,7 +82,6 @@ private:
     constexpr auto operator--()
     -> std::enable_if_t< std20::ranges::bidirectional_range< B >, iterator& > {
 
-
       this->next_ = this->current_;
       this->current_ = this->parent_->find_prev( this->next_ );
       return *this;
@@ -102,6 +101,11 @@ private:
     -> std::enable_if_t< std20::equality_comparable< std20::ranges::iterator_t< B > >, bool > {
 
       return left.current_ == right.current_;
+    }
+
+    friend constexpr bool operator==( const iterator& left, std20::ranges::default_sentinel_t ) {
+
+      return left.current_ == left.next_;
     }
 
     template < typename B = R >
@@ -172,7 +176,14 @@ public:
 
   constexpr iterator end() {
 
-    return { *this, std20::ranges::end( this->base_ ), std20::ranges::end( this->base_ ) };
+    if constexpr ( std20::ranges::common_range< R > ) {
+
+      return { *this, std20::ranges::end( this->base_ ), std20::ranges::end( this->base_ ) };
+    }
+    else {
+
+      return std20::ranges::default_sentinel;
+    }
   }
 
 };

--- a/src/tools/std23/views/stride.hpp
+++ b/src/tools/std23/views/stride.hpp
@@ -285,7 +285,7 @@ public:
 
   constexpr iterator< false > end() {
 
-    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R >) {
+    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R > ) {
 
       auto missing = ( this->stride_ - std20::ranges::distance( this->base_ ) % this->stride_ ) % this->stride_;
       return iterator< false >( this, std20::ranges::end( this->base_ ), missing );
@@ -302,7 +302,7 @@ public:
 
   constexpr iterator< true > end() const {
 
-    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R >) {
+    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R > ) {
 
       auto missing = ( this->stride_ - std20::ranges::distance( this->base_ ) % this->stride_ ) % this->stride_;
       return iterator< true >( this, std20::ranges::end( this->base_ ), missing );
@@ -335,6 +335,21 @@ public:
 
 template < typename R >
 stride_view( R&&, std20::ranges::range_difference_t< R > ) -> stride_view< std20::ranges::all_view< R > >;
+
+} // namespace ranges
+} // namespace std23
+
+namespace std20 {
+inline namespace ranges {
+
+template <typename R>
+inline constexpr bool enable_borrowed_range<std23::ranges::stride_view<R>> = enable_borrowed_range<R>;
+
+} // namespace ranges
+} // namespace std23
+
+namespace std23 {
+inline namespace ranges {
 
 namespace detail {
 

--- a/src/tools/std23/views/stride.hpp
+++ b/src/tools/std23/views/stride.hpp
@@ -273,11 +273,13 @@ public:
 
   constexpr R base() const { return base_; }
 
+  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0>
   constexpr iterator< false > begin() {
 
     return { this, std20::ranges::begin( this->base_ ) };
   }
 
+  template < typename RR = R, std::enable_if_t< std20::ranges::forward_range< const RR >, int > = 0 >
   constexpr iterator< true > begin() const {
 
     return { this, std20::ranges::begin( this->base_ ) };
@@ -303,7 +305,7 @@ public:
     }
   }
 
-  template < typename RR = R, std::enable_if_t< std20::ranges::range< const RR >, int > = 0 >
+  template < typename RR = R, std::enable_if_t< std20::ranges::forward_range< const RR >, int > = 0 >
   constexpr iterator< true > end() const {
 
     if constexpr ( std20::ranges::common_range< R > && 

--- a/src/tools/std23/views/stride.hpp
+++ b/src/tools/std23/views/stride.hpp
@@ -273,7 +273,7 @@ public:
 
   constexpr R base() const { return base_; }
 
-  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0>
+  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int >  = 0 >
   constexpr iterator< false > begin() {
 
     return { this, std20::ranges::begin( this->base_ ) };
@@ -285,11 +285,11 @@ public:
     return { this, std20::ranges::begin( this->base_ ) };
   }
 
-  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0>
+  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0 >
   constexpr iterator< false > end() {
 
-    if constexpr ( std20::ranges::common_range< R > && 
-                   std20::ranges::sized_range< R > && 
+    if constexpr ( std20::ranges::common_range< R > &&
+                   std20::ranges::sized_range< R > &&
                    std20::ranges::forward_range< R > ) {
 
       auto missing = ( this->stride_ - std20::ranges::distance( this->base_ ) % this->stride_ ) % this->stride_;
@@ -308,8 +308,8 @@ public:
   template < typename RR = R, std::enable_if_t< std20::ranges::forward_range< const RR >, int > = 0 >
   constexpr iterator< true > end() const {
 
-    if constexpr ( std20::ranges::common_range< R > && 
-                   std20::ranges::sized_range< R > && 
+    if constexpr ( std20::ranges::common_range< R > &&
+                   std20::ranges::sized_range< R > &&
                    std20::ranges::forward_range< R > ) {
 
       auto missing = ( this->stride_ - std20::ranges::distance( this->base_ ) % this->stride_ ) % this->stride_;
@@ -325,16 +325,16 @@ public:
     }
   }
 
-  template < typename B = R >
+  template < typename RR = R >
   constexpr auto size()
-  -> std::enable_if_t< std20::ranges::sized_range< B >, std::size_t > {
+  -> std::enable_if_t< std20::ranges::sized_range< RR >, std::size_t > {
 
     return div_ceil( std20::ranges::distance( this->base_ ), this->stride_ );
   }
 
-  template < typename B = R >
+  template < typename RR = R >
   constexpr auto size() const
-  -> std::enable_if_t< std20::ranges::sized_range< B >, std::size_t > {
+  -> std::enable_if_t< std20::ranges::sized_range< const RR >, std::size_t > {
 
     return div_ceil( std20::ranges::distance( this->base_ ), this->stride_ );
   }

--- a/src/tools/std23/views/stride.hpp
+++ b/src/tools/std23/views/stride.hpp
@@ -283,6 +283,7 @@ public:
     return { this, std20::ranges::begin( this->base_ ) };
   }
 
+  template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0>
   constexpr iterator< false > end() {
 
     if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R > ) {
@@ -300,9 +301,12 @@ public:
     }
   }
 
+  template < typename RR = R, std::enable_if_t< std20::ranges::range< const RR >, int > = 0 >
   constexpr iterator< true > end() const {
 
-    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R > ) {
+    if constexpr ( std20::ranges::common_range< R > && 
+                   std20::ranges::sized_range< R > && 
+                   std20::ranges::forward_range< R > ) {
 
       auto missing = ( this->stride_ - std20::ranges::distance( this->base_ ) % this->stride_ ) % this->stride_;
       return iterator< true >( this, std20::ranges::end( this->base_ ), missing );

--- a/src/tools/std23/views/stride.hpp
+++ b/src/tools/std23/views/stride.hpp
@@ -286,7 +286,9 @@ public:
   template < typename RR = R, std::enable_if_t< !std20::ranges::detail::simple_view< RR >, int>  = 0>
   constexpr iterator< false > end() {
 
-    if constexpr ( std20::ranges::common_range< R > && std20::ranges::sized_range< R > ) {
+    if constexpr ( std20::ranges::common_range< R > && 
+                   std20::ranges::sized_range< R > && 
+                   std20::ranges::forward_range< R > ) {
 
       auto missing = ( this->stride_ - std20::ranges::distance( this->base_ ) % this->stride_ ) % this->stride_;
       return iterator< false >( this, std20::ranges::end( this->base_ ), missing );
@@ -313,7 +315,7 @@ public:
     }
     else if constexpr ( std20::ranges::common_range< R > && ! std20::ranges::bidirectional_range< R >) {
 
-      return iterator< true >( this, std20::ranges::end( this->base_ ), 0 );
+      return iterator< true >( this, std20::ranges::end( this->base_ ) );
     }
     else {
 

--- a/src/tools/std23/views/test/stride.test.cpp
+++ b/src/tools/std23/views/test/stride.test.cpp
@@ -38,7 +38,7 @@ SCENARIO( "stride_view" ) {
         CHECK( ! std20::ranges::bidirectional_range< Range > );
         CHECK( ! std20::ranges::random_access_range< Range > );
         CHECK( ! std20::ranges::contiguous_range< Range > );
-        CHECK( std20::ranges::common_range< Range > );
+        CHECK( ! std20::ranges::common_range< Range > );
       }
 
       THEN( "a stride_view can be constructed and members can be tested" ) {
@@ -74,7 +74,7 @@ SCENARIO( "stride_view" ) {
         CHECK( std20::ranges::bidirectional_range< Range > );
         CHECK( ! std20::ranges::random_access_range< Range > );
         CHECK( ! std20::ranges::contiguous_range< Range > );
-        CHECK( std20::ranges::common_range< Range > );
+        CHECK( ! std20::ranges::common_range< Range > );
       }
 
       THEN( "a stride_view can be constructed and members can be tested" ) {
@@ -113,7 +113,7 @@ SCENARIO( "stride_view" ) {
         CHECK( std20::ranges::bidirectional_range< Range > );
         CHECK( std20::ranges::random_access_range< Range > );
         CHECK( ! std20::ranges::contiguous_range< Range > );
-        CHECK( std20::ranges::common_range< Range > );
+        CHECK( ! std20::ranges::common_range< Range > );
       }
 
       THEN( "a stride_view can be constructed and members can be tested" ) {

--- a/src/tools/std23/views/test/stride.test.cpp
+++ b/src/tools/std23/views/test/stride.test.cpp
@@ -38,7 +38,7 @@ SCENARIO( "stride_view" ) {
         CHECK( ! std20::ranges::bidirectional_range< Range > );
         CHECK( ! std20::ranges::random_access_range< Range > );
         CHECK( ! std20::ranges::contiguous_range< Range > );
-        CHECK( ! std20::ranges::common_range< Range > );
+        CHECK( std20::ranges::common_range< Range > );
       }
 
       THEN( "a stride_view can be constructed and members can be tested" ) {
@@ -74,7 +74,7 @@ SCENARIO( "stride_view" ) {
         CHECK( std20::ranges::bidirectional_range< Range > );
         CHECK( ! std20::ranges::random_access_range< Range > );
         CHECK( ! std20::ranges::contiguous_range< Range > );
-        CHECK( ! std20::ranges::common_range< Range > );
+        CHECK( std20::ranges::common_range< Range > );
       }
 
       THEN( "a stride_view can be constructed and members can be tested" ) {
@@ -113,7 +113,7 @@ SCENARIO( "stride_view" ) {
         CHECK( std20::ranges::bidirectional_range< Range > );
         CHECK( std20::ranges::random_access_range< Range > );
         CHECK( ! std20::ranges::contiguous_range< Range > );
-        CHECK( ! std20::ranges::common_range< Range > );
+        CHECK( std20::ranges::common_range< Range > );
       }
 
       THEN( "a stride_view can be constructed and members can be tested" ) {


### PR DESCRIPTION
This adds a test that adds common view uses in ENDFtk and ACEtk to ensure that everything is functioning correctly.

By looking into the actual standard specs and cppreference, I have updated the code to ensure the use cases all pass correctly. This mainly included setting enable_borrowed_range correctly, and updating some sfinae in the new views from c++23.