### PR TITLE
fix/python-views

### DIFF
--- a/src/tools/views/views-python.hpp
+++ b/src/tools/views/views-python.hpp
@@ -36,13 +36,13 @@ using BasicRandomAccessAnyView = njoy::tools::views::AnyRandomAccessView< Refere
  *  continue to use the Basic... versions of the any views.
  */
 template < typename ReferenceType >
-using InputAnyView = BasicInputAnyView< const ReferenceType& >;
+using InputAnyView = BasicInputAnyView< std::reference_wrapper< const ReferenceType > >;
 template < typename ReferenceType >
-using ForwardAnyView = BasicForwardAnyView< const ReferenceType& >;
+using ForwardAnyView = BasicForwardAnyView< std::reference_wrapper< const ReferenceType > >;
 template < typename ReferenceType >
-using BidirectionalAnyView = BasicBidirectionalAnyView< const ReferenceType& >;
+using BidirectionalAnyView = BasicBidirectionalAnyView< std::reference_wrapper< const ReferenceType > >;
 template < typename ReferenceType >
-using RandomAccessAnyView = BasicRandomAccessAnyView< const ReferenceType& >;
+using RandomAccessAnyView = BasicRandomAccessAnyView< std::reference_wrapper< const ReferenceType > >;
 
 /**
  *  @brief Some recurring basic views
@@ -193,7 +193,7 @@ void wrapBasicRandomAccessAnyViewOf( python::module& module, const std::string& 
 template < typename Element >
 void wrapBidirectionalAnyViewOf( python::module& module, const std::string& name ) {
 
-  wrapBasicBidirectionalAnyViewOf< const Element&, Element >( module, name );
+  wrapBasicBidirectionalAnyViewOf< std::reference_wrapper< const Element >, Element >( module, name );
 }
 
 /**
@@ -205,7 +205,7 @@ void wrapBidirectionalAnyViewOf( python::module& module, const std::string& name
 template < typename Element >
 void wrapRandomAccessAnyViewOf( python::module& module, const std::string& name ) {
 
-  wrapBasicRandomAccessAnyViewOf< const Element&, Element >( module, name );
+  wrapBasicRandomAccessAnyViewOf< std::reference_wrapper< const Element >, Element >( module, name );
 }
 
 #endif


### PR DESCRIPTION
While removing range-v3 from ENDFtk, we bumped into a case where the current version of tools views' python bindings did not compile since the reference type was a const T&. By reverting back to a std::reference_wrapper<const T>, we removed the issue.