### PR TITLE
Adding range type concept check

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,10 @@
 # Release Notes&mdash;tools
 Given here are some release notes for tools.
 
+## [tools v0.5.0](https://github.com/njoy/tools/pull/xx)
+Bug fixes:
+  - apply the ranges::range concept on the AnyView constructor taking a Container template as input (this fixes a rare compilation error encountered with the GitHub CI)
+
 ## [tools v0.4.0](https://github.com/njoy/tools/pull/44)
 New features:
   - added a partial implementation of the C++23 ranges standard: chunk_view, chunk_by_view, stride_view and repeat_view (LLVM implementations for these views were used as models for our C++17 based implementations)

--- a/src/tools/views/AnyView.hpp
+++ b/src/tools/views/AnyView.hpp
@@ -50,7 +50,8 @@ public:
    *
    *  @param[in] container    the container or range to be type erased
    */
-  template < typename Container >
+  template < typename Container,
+             typename = std::enable_if_t< njoy::tools::std20::ranges::range< Container > > >
   constexpr AnyView( Container&& container ) :
     AnyView( Iterator( container.begin() ), Iterator( container.end() ) ) {}
 


### PR DESCRIPTION
This adds a range type concept check to the Container template on the AnyView constructor. This removes the issue on ubuntu clang (github CI compilation error) in the range-v3 removal branch.

In the error, a variant of either a reference_wrapper or AnyView needed to be created and the compiler got confused and tried to create an AnyView using a reference_wrapper, which fails because a reference_wrapper obviously does not have a begin() and end() method. Adding the concept switches off the constructor in this case, causing the compilation to no longer fail.