### PR TITLE
Fix Log.hpp to enable building ACEtk with MSVC19

### DIFF
--- a/src/tools/Log.hpp
+++ b/src/tools/Log.hpp
@@ -16,9 +16,9 @@ namespace tools {
  */
 class Log {
 
-  static auto initialize_logger() {
+  static static std::shared_ptr<spdlog::logger> initialize_logger() {
 
-    auto instance = spdlog::stdout_color_st( "njoy" );
+    static std::shared_ptr<spdlog::logger> instance = spdlog::stdout_color_st( "njoy" );
     instance->set_pattern( "[%^%l%$] %v" );
     #ifndef NDEBUG
     instance->set_level( spdlog::level::debug );
@@ -26,9 +26,9 @@ class Log {
     return instance;
   }
 
-  static auto& logger() {
+  static static std::shared_ptr<spdlog::logger>& logger() {
 
-    static auto instance = initialize_logger();
+    static static std::shared_ptr<spdlog::logger> instance = initialize_logger();
     return instance;
   }
 

--- a/src/tools/Log.hpp
+++ b/src/tools/Log.hpp
@@ -16,9 +16,9 @@ namespace tools {
  */
 class Log {
 
-  static static std::shared_ptr<spdlog::logger> initialize_logger() {
+  static std::shared_ptr<spdlog::logger> initialize_logger() {
 
-    static std::shared_ptr<spdlog::logger> instance = spdlog::stdout_color_st( "njoy" );
+    std::shared_ptr<spdlog::logger> instance = spdlog::stdout_color_st( "njoy" );
     instance->set_pattern( "[%^%l%$] %v" );
     #ifndef NDEBUG
     instance->set_level( spdlog::level::debug );
@@ -26,9 +26,9 @@ class Log {
     return instance;
   }
 
-  static static std::shared_ptr<spdlog::logger>& logger() {
+  static std::shared_ptr<spdlog::logger>& logger() {
 
-    static static std::shared_ptr<spdlog::logger> instance = initialize_logger();
+    static std::shared_ptr<spdlog::logger> instance = initialize_logger();
     return instance;
   }
 


### PR DESCRIPTION
The use of `auto` as the return type of functions in Log.hpp causes MSVC19 to throw a hissy fit when trying to build `tools` as a dependency of `ACEtk` on Windows. This PR specifies the function return types explicitly so that `ACEtk` can be built on Windows.