### PR TITLE
Fix Unknown Compiler Flag Warning on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if( tools.python )
 
   target_link_libraries( tools.python PRIVATE tools )
   target_include_directories( tools.python PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/python/src )
-  target_compile_options( tools.python PRIVATE "-fvisibility=hidden" )
+  set_target_properties( tools.python PROPERTIES CXX_VISIBILITY_PRESET hidden)
   set_target_properties( tools.python PROPERTIES OUTPUT_NAME tools )
   set_target_properties( tools.python PROPERTIES COMPILE_DEFINITIONS "PYBIND11" )
   set_target_properties( tools.python PROPERTIES POSITION_INDEPENDENT_CODE ON )


### PR DESCRIPTION
MSVC does not have a `-fvisibility=hidden` option. Instead, when compiling a shared object, all symbols are hidden by default. When building tools on Windows, I was getting compiler errors due to this GCC style flag being passed. I fixed this by simply using the built-in CMake property, so it should be handled in a compiler/OS agnostic manner now.